### PR TITLE
Implement Sprite Exec Capability

### DIFF
--- a/.wreckit/items/074-sprites-dev-authentication/item.json
+++ b/.wreckit/items/074-sprites-dev-authentication/item.json
@@ -3,14 +3,8 @@
   "id": "074-sprites-dev-authentication",
   "title": "Align Sprite Integration with Real CLI & Token",
   "section": "infrastructure",
-  "state": "critique",
+  "state": "done",
   "overview": "Update the existing Sprite integration to use the official `sprite` CLI commands (`create`, `console`) and authenticate using the provided Sprites.dev API token. This refactors Item 073 to match the actual production environment.",
-  "branch": null,
-  "pr_url": null,
-  "pr_number": null,
-  "last_error": null,
-  "created_at": "2026-01-27T23:30:00.000Z",
-  "updated_at": "2026-01-27T23:41:53.060Z",
   "problem_statement": "Item 073 targeted a generic `wisp` binary. The real tool is `sprite`, uses different subcommands, and requires a token.",
   "motivation": "To make the Sprite integration functional with the user's actual credentials.",
   "success_criteria": [
@@ -30,5 +24,11 @@
   ],
   "scope_out_of_scope": [],
   "priority_hint": "high",
-  "urgency_hint": "Fixing broken integration"
+  "urgency_hint": "Fixing broken integration",
+  "branch": "wreckit/074-sprites-dev-authentication",
+  "pr_url": "https://github.com/jmanhype/wreckit/pull/30",
+  "pr_number": 30,
+  "last_error": null,
+  "created_at": "2026-01-27T23:30:00.000Z",
+  "updated_at": "2026-01-28T00:00:00.000Z"
 }

--- a/.wreckit/items/075-implement-sprite-exec/item.json
+++ b/.wreckit/items/075-implement-sprite-exec/item.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": 1,
+  "id": "075-implement-sprite-exec",
+  "title": "Implement Sprite Exec Capability",
+  "section": "infrastructure",
+  "state": "critique",
+  "overview": "Add the ability to execute commands inside a running Sprite VM via the `sprite exec` CLI command. This enables Wreckit agents to perform work (clone, build, test) inside the sandbox, not just manage the VM lifecycle.",
+  "branch": null,
+  "pr_url": null,
+  "pr_number": null,
+  "last_error": null,
+  "created_at": "2026-01-27T23:55:00.000Z",
+  "updated_at": "2026-01-28T00:11:10.247Z",
+  "problem_statement": "The current Sprite integration supports lifecycle (start/stop) but not execution. Agents cannot run commands inside the isolated environment.",
+  "motivation": "To fully realize 'Sandbox Mode', agents need to execute shell commands within the Sprite VM.",
+  "success_criteria": [
+    "`SpriteRunner` supports `exec` method wrapping `sprite exec`",
+    "`wreckit sprite exec <name> -- <command>` CLI command implemented",
+    "`exec_in_sprite` RLM tool available to agents",
+    "Support for capturing stdout/stderr/exit code from inside the VM",
+    "Integration tests mocking `sprite exec`"
+  ],
+  "technical_constraints": [
+    "Must use `child_process.spawn`",
+    "Must handle streaming output",
+    "Must propagate exit codes correctly"
+  ],
+  "scope_in_scope": [
+    "src/agent/sprite-runner.ts",
+    "src/commands/sprite.ts",
+    "src/agent/rlm-tools.ts",
+    "src/__tests__/commands/sprite.test.ts"
+  ],
+  "scope_out_of_scope": [],
+  "priority_hint": "high",
+  "urgency_hint": "Missing core capability"
+}

--- a/.wreckit/items/075-implement-sprite-exec/plan.md
+++ b/.wreckit/items/075-implement-sprite-exec/plan.md
@@ -1,0 +1,80 @@
+# Implement Sprite Exec Capability Implementation Plan
+
+## Overview
+
+Add the ability to execute commands inside a running Sprite VM via the `sprite exec` CLI command. This enables Wreckit agents to perform work (clone, build, test) inside the sandbox, not just manage the VM lifecycle.
+
+## Current State Analysis
+
+The current Sprite integration (Items 073 and 074) provides lifecycle management only:
+
+**Existing Sprite Operations** (`src/agent/sprite-runner.ts`):
+- `startSprite()` → Maps to `sprite create <name>` (line 258)
+- `attachSprite()` → Maps to `sprite console <name>` (line 303)
+- `listSprites()` → Maps to `sprite list --json` (line 338)
+- `killSprite()` → Maps to `sprite delete <name>` (line 372)
+
+**Core Infrastructure**:
+- `runWispCommand()` primitive (lines 85-207) handles subprocess execution with timeout enforcement, streaming output capture via callbacks, and SIGTERM→SIGKILL escalation
+- Error handling system (`src/errors.ts:408-463`) includes `WispNotFoundError`, `SpriteStartError`, `SpriteAttachError`, `SpriteKillError` but **lacks** `SpriteExecError`
+- CLI commands (`src/commands/sprite.ts:81-375`) follow consistent pattern with options interfaces, config loading, and JSON output support
+- RLM tools (`src/agent/rlm-tools.ts:244-450`) expose `SpawnSprite`, `AttachSprite`, `ListSprites`, `KillSprite` tools for agents
+- CLI registration (`src/index.ts:444-558`) registers sprite subcommands under `wreckit sprite` command group
+
+**What's Missing**:
+- No `execSprite()` function in `sprite-runner.ts`
+- No `spriteExecCommand` in `commands/sprite.ts`
+- No `sprite exec` subcommand registered in `src/index.ts`
+- No `ExecSprite` tool in RLM registry
+- No `SpriteExecError` class in `src/errors.ts`
+- No tests for exec functionality
+
+## Phases
+
+### Phase 1: Core Infrastructure (Foundation)
+
+**Overview**: Add error handling (`SpriteExecError`) and implement the core `execSprite()` function that wraps `runWispCommand()`. This establishes the foundation for CLI and RLM layers.
+
+#### Changes Required
+
+1. **Add Error Code and Error Class** in `src/errors.ts`:
+   - Add `SPRITE_EXEC_FAILED` to `ErrorCodes`
+   - Create `SpriteExecError` class
+
+2. **Implement execSprite() Function** in `src/agent/sprite-runner.ts`:
+   - Add `execSprite()` function
+   - Handle subprocess errors vs command failures
+
+### Phase 2: CLI Integration (User Interface)
+
+**Overview**: Implement the CLI command and register it with Commander.js.
+
+#### Changes Required
+
+1. **Add Command Options Interface** in `src/commands/sprite.ts`:
+   - `SpriteExecOptions`
+
+2. **Implement CLI Command** in `src/commands/sprite.ts`:
+   - `spriteExecCommand()`
+
+3. **Register CLI Command** in `src/index.ts`:
+   - Register `sprite exec` subcommand
+
+### Phase 3: RLM Tool Integration (Agent Access)
+
+**Overview**: Expose `ExecSprite` as an RLM tool so agents can execute commands inside Sprites.
+
+#### Changes Required
+
+1. **Create ExecSpriteTool** in `src/agent/rlm-tools.ts`:
+   - Implement `ExecSpriteTool`
+   - Register in `ALL_TOOLS`
+
+### Phase 4: Testing & Polish (Quality Assurance)
+
+**Overview**: Add comprehensive unit tests to ensure correctness and prevent regressions.
+
+#### Changes Required
+
+1. **Add Unit Tests** in `src/__tests__/commands/sprite.test.ts`:
+   - Test `spriteExecCommand` success/failure/json/error paths

--- a/.wreckit/items/075-implement-sprite-exec/prd.json
+++ b/.wreckit/items/075-implement-sprite-exec/prd.json
@@ -1,0 +1,171 @@
+{
+  "schema_version": 1,
+  "id": "075-implement-sprite-exec",
+  "branch_name": "wreckit/075-implement-sprite-exec",
+  "user_stories": [
+    {
+      "id": "US-075-001",
+      "title": "Add SpriteExecError error class and SPRITE_EXEC_FAILED error code",
+      "acceptance_criteria": [
+        "SPRITE_EXEC_FAILED added to ErrorCodes enum in src/errors.ts (line 57)",
+        "SpriteExecError class created extending WreckitError",
+        "SpriteExecError includes spriteName and message in error context",
+        "SpriteExecError matches pattern of SpriteStartError, SpriteAttachError, SpriteKillError",
+        "Error class is importable and type-checking passes"
+      ],
+      "priority": 1,
+      "status": "done",
+      "notes": "Foundation error handling must be in place before using it in execSprite() function."
+    },
+    {
+      "id": "US-075-002",
+      "title": "Implement execSprite() core function in sprite-runner.ts",
+      "acceptance_criteria": [
+        "execSprite() function exported from src/agent/sprite-runner.ts",
+        "Function accepts name, command[], config, logger, and optional streaming callbacks",
+        "Function calls runWispCommand() with args ['exec', name, ...command]",
+        "Function returns WispResult with exitCode, stdout, stderr, success",
+        "Function throws SpriteExecError for subprocess errors (spawn failure, timeout)",
+        "Function does NOT throw for command failures (non-zero exit code returns success=false)",
+        "Function throws WispNotFoundError if Sprite binary not found",
+        "Function includes JSDoc documentation with usage example",
+        "Module comment updated to include 'exec: Execute a command inside a running Sprite'",
+        "Type-checking passes (npm run typecheck)"
+      ],
+      "priority": 1,
+      "status": "done",
+      "notes": "Core primitive that both CLI and RLM layers depend on. Must distinguish between subprocess errors (throw) and command failures (return success=false)."
+    },
+    {
+      "id": "US-075-003",
+      "title": "Add SpriteExecOptions interface to sprite.ts",
+      "acceptance_criteria": [
+        "SpriteExecOptions interface defined in src/commands/sprite.ts",
+        "Interface includes: name: string, command: string[], cwd?: string, json?: boolean",
+        "Interface matches pattern of SpriteStartOptions, SpriteListOptions, etc.",
+        "Type-checking passes"
+      ],
+      "priority": 2,
+      "status": "done",
+      "notes": "Simple interface definition, no logic. Follow existing patterns."
+    },
+    {
+      "id": "US-075-004",
+      "title": "Implement spriteExecCommand() in sprite.ts",
+      "acceptance_criteria": [
+        "spriteExecCommand() function defined in src/commands/sprite.ts",
+        "Function imports execSprite from sprite-runner",
+        "Function imports SpriteExecError from errors",
+        "Function calls getSpriteConfig() to load and validate config",
+        "Function calls execSprite() with name, command, config, logger",
+        "Function outputs human-readable format with emoji prefixes (✅/❌) by default",
+        "Function outputs JSON format when --json flag provided",
+        "JSON output includes: success, message, data.name, data.command, data.exitCode, data.stdout, data.stderr",
+        "Function catches SpriteExecError and outputs error message",
+        "Function catches WispNotFoundError and outputs error message",
+        "Function exits with code 1 for command failures (non-zero exit code)",
+        "Function includes JSDoc with usage examples",
+        "Type-checking passes"
+      ],
+      "priority": 2,
+      "status": "done",
+      "notes": "CLI command implementation. Must handle both success and failure paths with appropriate output formats. Follow spriteStartCommand pattern."
+    },
+    {
+      "id": "US-075-005",
+      "title": "Register sprite exec subcommand in CLI",
+      "acceptance_criteria": [
+        "spriteExecCommand imported in src/index.ts",
+        "'exec' subcommand registered with spriteCmd at src/index.ts",
+        "Command uses .command('exec <name> <command...>') for variadic argument capture",
+        "Command includes --json option",
+        "Command description: 'Execute a command inside a running Sprite VM'",
+        "Command action wires up executeCommand wrapper with global options",
+        "Command respects --cwd, --verbose, --quiet, --dry-run global options",
+        "wreckit sprite --help shows 'exec' subcommand",
+        "wreckit sprite exec --help shows usage and options",
+        "Build succeeds (npm run build)"
+      ],
+      "priority": 2,
+      "status": "done",
+      "notes": "CLI registration. Variadic arguments capture all command parts into array automatically."
+    },
+    {
+      "id": "US-075-006",
+      "title": "Create ExecSpriteTool in rlm-tools.ts",
+      "acceptance_criteria": [
+        "ExecSpriteTool constant defined in src/agent/rlm-tools.ts",
+        "Tool name: 'ExecSprite'",
+        "Tool description: 'Execute a command inside a running Sprite VM. Returns command output and exit code.'",
+        "Tool parameters: name (string, required), command (array of strings, required)",
+        "Tool uses dynamic import to avoid circular dependency",
+        "Tool calls execSprite() with DEFAULT_SPRITE_CONFIG and spriteLogger",
+        "Tool returns JSON.stringify() result with success, message, data fields",
+        "Tool catches all errors and returns as JSON (never throws)",
+        "Tool returns success=false with exitCode for command failures (non-zero exit)",
+        "Type-checking passes"
+      ],
+      "priority": 3,
+      "status": "done",
+      "notes": "RLM tool for agent access. Must catch errors and return as JSON to avoid crashing RLM framework."
+    },
+    {
+      "id": "US-075-007",
+      "title": "Register ExecSprite tool in RLM tool registry",
+      "acceptance_criteria": [
+        "ExecSprite: ExecSpriteTool added to ALL_TOOLS registry in src/agent/rlm-tools.ts",
+        "buildToolRegistry() includes ExecSprite when allowedTools includes it",
+        "Tool accessible to agents via buildToolRegistry() function",
+        "Type-checking passes"
+      ],
+      "priority": 3,
+      "status": "done",
+      "notes": "Simple registration in existing tool registry."
+    },
+    {
+      "id": "US-075-008",
+      "title": "Add unit tests for spriteExecCommand",
+      "acceptance_criteria": [
+        "spriteExecCommand imported in src/__tests__/commands/sprite.test.ts",
+        "describe('spriteExecCommand', ...) test suite added",
+        "Test for successful execution with mocked spawn()",
+        "Test verifies correct arguments passed to spawn()",
+        "Test verifies success message includes Sprite name",
+        "Test for command failure (non-zero exit code)",
+        "Test verifies error message includes exit code",
+        "Test verifies process.exit(1) called for command failures",
+        "Test for JSON output format with --json flag",
+        "Test verifies JSON.parse() succeeds on output",
+        "Test verifies JSON includes success, message, data.exitCode, data.stdout, data.stderr",
+        "Test for Sprite binary not found error (ENOENT)",
+        "Test verifies error message includes 'not found'",
+        "Test for both stdout and stderr output",
+        "Test verifies both console.log and console.error called",
+        "All tests pass: npm test -- src/__tests__/commands/sprite.test.ts",
+        "No regressions in existing Sprite command tests"
+      ],
+      "priority": 4,
+      "status": "done",
+      "notes": "Comprehensive test coverage using existing mock helpers (mockSpawnSuccess, mockSpawnFailure, mockSpawnError)."
+    },
+    {
+      "id": "US-075-009",
+      "title": "Integration testing and verification",
+      "acceptance_criteria": [
+        "wreckit sprite --help displays exec subcommand",
+        "wreckit sprite exec --help shows usage",
+        "Command accepts variadic arguments (e.g., wreckit sprite exec my-vm ls -la)",
+        "Command executes without TypeScript errors",
+        "Command outputs human-readable format by default",
+        "Command outputs valid JSON with --json flag",
+        "Error handling works for Sprite not found",
+        "Error handling works for command failures",
+        "Existing Sprite commands (start/attach/list/kill) still work",
+        "All automated checks pass: typecheck, lint, build, test"
+      ],
+      "priority": 4,
+      "status": "done",
+      "notes": "Final verification that everything integrates correctly. Manual testing of CLI help and basic functionality."
+    }
+  ]
+}

--- a/.wreckit/items/075-implement-sprite-exec/research.md
+++ b/.wreckit/items/075-implement-sprite-exec/research.md
@@ -1,0 +1,568 @@
+# Research: Implement Sprite Exec Capability
+
+**Date**: 2025-01-27
+**Item**: 075-implement-sprite-exec
+
+## Research Question
+Add the ability to execute commands inside a running Sprite VM via the `sprite exec` CLI command. This enables Wreckit agents to perform work (clone, build, test) inside the sandbox, not just manage the VM lifecycle.
+
+## Summary
+
+The current Sprite integration (Items 073 and 074) provides lifecycle management (start/attach/list/kill) but lacks the ability to execute commands inside running VMs. This research identifies that implementing `sprite exec` requires extending the existing `sprite-runner.ts` infrastructure with a new `execSprite()` function, adding a `spriteExecCommand` to the CLI, exposing an `ExecSprite` RLM tool for agents, and creating comprehensive error handling for command execution failures.
+
+The codebase already has excellent patterns to follow. The `runWispCommand()` primitive at `src/agent/sprite-runner.ts:85-207` demonstrates proper subprocess management with timeout handling, streaming output capture via `onStdoutChunk`/`onStderrChunk` callbacks, and SIGTERM→SIGKILL escalation. The existing command implementations in `src/commands/sprite.ts:81-375` show the pattern for CLI option interfaces, configuration validation, and JSON output support. RLM tools in `src/agent/rlm-tools.ts:244-450` provide the template for agent-accessible tools with proper error handling and JSON responses.
+
+Key findings reveal that Item 074 already refactored the CLI from generic `wisp` commands to the official `sprite` CLI with correct subcommand mapping (`start→create`, `attach→console`, `kill→delete`). The authentication token system is in place via `SPRITES_TOKEN` environment variable injection at `src/agent/sprite-runner.ts:91-96`. However, there's no `exec` command implementation yet, and the error handling system at `src/errors.ts:408-463` lacks execution-specific error classes like `SpriteExecError`.
+
+## Current State Analysis
+
+### Existing Implementation
+
+**Sprite Runner Architecture**: `src/agent/sprite-runner.ts:1-540` implements the core Sprite integration:
+
+- **Core Primitive**: `runWispCommand()` at lines 85-207 handles all subprocess execution
+  - Uses `child_process.spawn` (line 106)
+  - Supports streaming output via `onStdoutChunk` and `onStderrChunk` callbacks (lines 46-49, 162-177)
+  - Implements SIGTERM→SIGKILL escalation for timeouts (lines 140-158)
+  - Handles ENOENT errors for missing binary (lines 115-125)
+  - Injects `SPRITES_TOKEN` environment variable when present (lines 91-96)
+
+- **Lifecycle Operations**: Lines 246-394 implement VM management
+  - `startSprite()` (lines 253-288): Maps to `sprite create <name>`
+  - `attachSprite()` (lines 298-325): Maps to `sprite console <name>`
+  - `listSprites()` (lines 334-357): Maps to `sprite list --json`
+  - `killSprite()` (lines 367-394): Maps to `sprite delete <name>`
+  - **Missing**: No `execSprite()` function for command execution
+
+- **Error Handling**: Custom error classes at `src/errors.ts:408-463`
+  - `WispNotFoundError` (line 414): Binary not found
+  - `SpriteStartError` (line 429): VM start failure
+  - `SpriteAttachError` (line 442): Attach failure
+  - `SpriteKillError` (line 455): Termination failure
+  - **Missing**: No `SpriteExecError` for command execution failures
+
+**CLI Commands**: `src/commands/sprite.ts:1-376` provides user-facing commands:
+
+- **Command Pattern**: All commands follow consistent structure
+  - Options interface (e.g., `SpriteStartOptions` at lines 18-24)
+  - Configuration loading via `getSpriteConfig()` (lines 50-63)
+  - JSON output support via `--json` flag
+  - Success/error handling with emoji prefixes (✅/❌)
+
+- **Existing Commands**:
+  - `spriteStartCommand` (lines 81-151): Start VM with optional --memory/--cpus flags
+  - `spriteListCommand` (lines 158-239): List active VMs
+  - `spriteKillCommand` (lines 246-307): Terminate VM
+  - `spriteAttachCommand` (lines 314-375): Attach to VM console
+  - **Missing**: No `spriteExecCommand` for command execution
+
+- **CLI Registration**: `src/index.ts:444-558` registers sprite commands
+  - Main `sprite` command group at line 444
+  - Subcommands registered via `program.command()` (lines 449-558)
+  - **Missing**: No `sprite exec <name> -- <command>` registration
+
+**RLM Tools**: `src/agent/rlm-tools.ts:211-450` exposes Sprite operations to agents:
+
+- **Sprite Management Tools** (lines 244-450):
+  - `SpawnSpriteTool` (lines 244-301): Create VM
+  - `AttachSpriteTool` (lines 310-353): Attach to console
+  - `ListSpritesTool` (lines 361-399): List VMs
+  - `KillSpriteTool` (lines 407-450): Terminate VM
+  - **Missing**: No `ExecSpriteTool` for command execution
+
+- **DEFAULT_SPRITE_CONFIG** (lines 211-219): Provides defaults for RLM tools
+  - `wispPath: "sprite"` (note: still named `wispPath` for backward compatibility)
+  - `token: process.env.SPRITES_TOKEN` (line 218)
+  - Resource limits: `maxVMs: 5`, `defaultMemory: "512MiB"`, `defaultCPUs: "1"`, `timeout: 300`
+
+**Configuration System**: `src/schemas.ts:72-80` defines Sprite configuration:
+
+```typescript
+export const SpriteAgentSchema = z.object({
+  kind: z.literal("sprite"),
+  wispPath: z.string().default("sprite").describe("Path to sprite CLI binary"),
+  token: z.string().optional().describe("Sprites.dev authentication token"),
+  maxVMs: z.number().default(5),
+  defaultMemory: z.string().default("512MiB"),
+  defaultCPUs: z.string().default("1"),
+  timeout: z.number().default(300),
+});
+```
+
+**Testing Pattern**: `src/__tests__/commands/sprite.test.ts:1-454` shows mocking approach:
+
+- Mock `spawn()` using `spyOn(global, "spawn")` (lines 69-121)
+- Simulate stdout/stderr via Buffer callbacks (lines 71-80)
+- Test success/error paths for each command
+- **Missing**: No tests for `exec` command
+
+### Key Files
+
+| File | Purpose | Lines of Interest | Changes Required |
+|------|---------|-------------------|------------------|
+| `src/agent/sprite-runner.ts` | Core Sprite operations | 85-207 (`runWispCommand`), 246-394 (lifecycle ops) | Add `execSprite()` function |
+| `src/commands/sprite.ts` | CLI command implementations | 1-376 (all commands) | Add `spriteExecCommand` and options interface |
+| `src/index.ts` | CLI registration | 444-558 (sprite commands) | Register `sprite exec` subcommand |
+| `src/agent/rlm-tools.ts` | RLM agent tools | 244-450 (sprite tools) | Add `ExecSpriteTool` |
+| `src/errors.ts` | Error handling | 15-61 (ErrorCodes), 408-463 (sprite errors) | Add `SpriteExecError` class and code |
+| `src/__tests__/commands/sprite.test.ts` | Integration tests | 1-454 | Add tests for exec command |
+
+## Technical Considerations
+
+### Dependencies
+
+**External Dependencies**:
+- `sprite` CLI from Sprites.dev (already required by Item 074)
+- No additional npm packages (use existing `spawn` from `node:child_process`)
+
+**Internal Modules** to integrate with:
+- `src/agent/sprite-runner.ts:85-207` - Reuse `runWispCommand()` primitive
+- `src/commands/sprite.ts:81-375` - Follow existing command pattern
+- `src/agent/rlm-tools.ts:244-450` - Add new tool to registry
+- `src/errors.ts:408-463` - Add execution error class
+- `src/index.ts:444-558` - Register new CLI command
+
+### Patterns to Follow
+
+**1. Sprite Runner Pattern** (`src/agent/sprite-runner.ts`):
+
+Create `execSprite()` function following the existing lifecycle operations:
+
+```typescript
+export async function execSprite(
+  name: string,
+  command: string[],
+  config: SpriteAgentConfig,
+  logger: Logger,
+  options?: {
+    onStdoutChunk?: (chunk: string) => void;
+    onStderrChunk?: (chunk: string) => void;
+  }
+): Promise<WispResult> {
+  const args = ["exec", name, ...command];
+
+  logger.debug(`Executing in Sprite: ${config.wispPath} ${args.join(" ")}`);
+
+  const result = await runWispCommand(args, {
+    wispPath: config.wispPath,
+    logger,
+    timeout: config.timeout,
+    token: config.token,
+    onStdoutChunk: options?.onStdoutChunk,
+    onStderrChunk: options?.onStderrChunk,
+  });
+
+  if (result.error?.includes("not found")) {
+    throw new WispNotFoundError(config.wispPath);
+  }
+
+  if (!result.success) {
+    throw new SpriteExecError(name, result.stderr || result.error || "Command execution failed");
+  }
+
+  return result;
+}
+```
+
+**2. CLI Command Pattern** (`src/commands/sprite.ts:81-375`):
+
+Follow the existing structure:
+
+```typescript
+export interface SpriteExecOptions {
+  name: string;
+  command: string[];  // Command and arguments to execute
+  cwd?: string;
+  json?: boolean;
+}
+
+export async function spriteExecCommand(
+  options: SpriteExecOptions,
+  logger: Logger
+): Promise<void> {
+  const cwd = options.cwd ?? process.cwd();
+  const config = await getSpriteConfig(cwd);
+
+  logger.debug(`Executing command in Sprite '${options.name}'...`);
+
+  try {
+    const result = await execSprite(options.name, options.command, config, logger);
+
+    if (result.success) {
+      const outputData = {
+        success: true,
+        message: `Executed command in Sprite '${options.name}'`,
+        data: {
+          name: options.name,
+          command: options.command,
+          exitCode: result.exitCode,
+          stdout: result.stdout.trim(),
+          stderr: result.stderr.trim(),
+        },
+      };
+
+      if (options.json) {
+        outputJson(outputData);
+      } else {
+        console.log(`✅ ${outputData.message}`);
+        if (result.stdout.trim()) {
+          console.log(`\nOutput:\n${result.stdout.trim()}`);
+        }
+      }
+    } else {
+      // Error handling...
+    }
+  } catch (err) {
+    // Error handling...
+  }
+}
+```
+
+**3. RLM Tool Pattern** (`src/agent/rlm-tools.ts:244-450`):
+
+Create `ExecSpriteTool` following existing tools:
+
+```typescript
+const ExecSpriteTool: AxFunction = {
+  name: "ExecSprite",
+  description: "Execute a command inside a running Sprite VM. Returns command output and exit code.",
+  parameters: {
+    type: "object",
+    properties: {
+      name: {
+        type: "string",
+        description: "Name/ID of the Sprite VM to execute command in",
+      },
+      command: {
+        type: "array",
+        items: { type: "string" },
+        description: "Command and arguments to execute (e.g., ['npm', 'install'])",
+      },
+    },
+    required: ["name", "command"],
+  } as AxFunctionJSONSchema,
+  func: async ({ name, command }: { name: string; command: string[] }) => {
+    try {
+      const { execSprite } = await import("./sprite-runner.js");
+
+      const result = await execSprite(name, command, DEFAULT_SPRITE_CONFIG, spriteLogger);
+
+      if (result.success) {
+        return JSON.stringify({
+          success: true,
+          message: `Executed command in Sprite '${name}'`,
+          data: {
+            name,
+            command,
+            exitCode: result.exitCode,
+            stdout: result.stdout,
+            stderr: result.stderr,
+          },
+        }, null, 2);
+      } else {
+        return JSON.stringify({
+          success: false,
+          error: result.stderr || result.error || "Command execution failed",
+        }, null, 2);
+      }
+    } catch (error: any) {
+      return JSON.stringify({
+        success: false,
+        error: error.message || "Unknown error executing command",
+      }, null, 2);
+    }
+  },
+};
+```
+
+**4. CLI Registration Pattern** (`src/index.ts:444-558`):
+
+Register the new command after `sprite attach`:
+
+```typescript
+spriteCmd
+  .command("exec <name> <command...>")
+  .description("Execute a command inside a running Sprite VM")
+  .option("--json", "Output as JSON")
+  .action(async (name, command, options, cmd) => {
+    const globalOpts = cmd.optsWithGlobals();
+    await executeCommand(
+      async () => {
+        await spriteExecCommand(
+          {
+            name,
+            command,
+            cwd: resolveCwd(globalOpts.cwd),
+            json: options.json,
+          },
+          logger,
+        );
+      },
+      logger,
+      {
+        verbose: globalOpts.verbose,
+        quiet: globalOpts.quiet,
+        dryRun: globalOpts.dryRun,
+        cwd: resolveCwd(globalOpts.cwd),
+      },
+    );
+  });
+```
+
+**5. Error Handling Pattern** (`src/errors.ts:408-463`):
+
+Add execution-specific error class:
+
+```typescript
+/**
+ * Thrown when command execution inside a Sprite VM fails.
+ */
+export class SpriteExecError extends WreckitError {
+  constructor(
+    public readonly spriteName: string,
+    message: string,
+  ) {
+    super(`Failed to execute command in Sprite '${spriteName}': ${message}`, ErrorCodes.SPRITE_EXEC_FAILED);
+    this.name = "SpriteExecError";
+  }
+}
+```
+
+Update `ErrorCodes` enum at lines 15-61:
+
+```typescript
+export const ErrorCodes = {
+  // ... existing codes ...
+  SPRITE_EXEC_FAILED: "SPRITE_EXEC_FAILED",
+} as const;
+```
+
+**6. Testing Pattern** (`src/__tests__/commands/sprite.test.ts`):
+
+Add tests following existing structure:
+
+```typescript
+describe("spriteExecCommand", () => {
+  let tempDir: string;
+  let mockLogger: Logger & { messages: string[] };
+
+  beforeEach(async () => {
+    mockLogger = createMockLogger();
+  });
+
+  afterEach(async () => {
+    if (tempDir) {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("executes a command in a Sprite successfully", async () => {
+    tempDir = await setupTempGitRepo();
+    await setupSpriteConfig(tempDir);
+
+    const mockStdout = "Command output\n";
+    const spawnSpy = mockSpawnSuccess(mockStdout);
+
+    const consoleSpy = spyOn(console, "log");
+    await spriteExecCommand(
+      { name: "test-sprite", command: ["ls", "-la"], cwd: tempDir },
+      mockLogger
+    );
+
+    expect(spawnSpy).toHaveBeenCalledWith("sprite", [
+      "exec",
+      "test-sprite",
+      "ls",
+      "-la",
+    ]);
+
+    const calls = consoleSpy.mock.calls.map((c) => String(c[0]));
+    expect(calls.some((c) => c.includes("Executed command in Sprite 'test-sprite'"))).toBe(true);
+
+    consoleSpy.mockRestore();
+    spawnSpy.mockRestore();
+  });
+
+  it("handles command execution failure", async () => {
+    tempDir = await setupTempGitRepo();
+    await setupSpriteConfig(tempDir);
+
+    const spawnSpy = mockSpawnFailure(1, "Command not found\n");
+
+    const consoleSpy = spyOn(console, "error");
+    const exitSpy = spyOn(process, "exit").mockImplementation((code) => {
+      throw new Error(`Process exited with code ${code}`);
+    });
+
+    await expect(
+      spriteExecCommand(
+        { name: "test-sprite", command: ["invalid"], cwd: tempDir },
+        mockLogger
+      )
+    ).rejects.toThrow();
+
+    consoleSpy.mockRestore();
+    exitSpy.mockRestore();
+    spawnSpy.mockRestore();
+  });
+});
+```
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| **Command injection vulnerabilities** | High - Security breach | Validate command arguments; avoid shell interpretation; use array form of `spawn()` with explicit arguments |
+| **Sprite VM not running** | Medium - Command fails | Check VM state before exec; provide clear error message if VM not found or stopped |
+| **Long-running commands** | Medium - Timeout/hang | Respect `config.timeout` (default 300s); allow streaming output via callbacks; implement SIGTERM→SIGKILL escalation |
+| **Output buffer overflow** | Low - Memory issues | Stream output via `onStdoutChunk`/`onStderrChunk` callbacks; don't buffer entire output in memory |
+| **Exit code propagation** | Medium - Silent failures | Capture and return exit code; distinguish between success (0) and failure (non-zero); expose in JSON output |
+| **Command with special characters** | Low - Parsing issues | Pass command as array to `spawn()`; avoid shell string interpolation; test with quotes, spaces, pipes |
+| **Sprite CLI version compatibility** | Medium - Breaking changes | Document minimum Sprite CLI version; handle missing `exec` subcommand gracefully |
+| **Authentication token expiration during exec** | Low - Intermittent failures | Token already injected via environment (line 91-96); if token expires, fail with auth error |
+| **Concurrent exec calls to same VM** | Low - Race conditions | Sprite CLI should handle serialization; document limitation if issues arise |
+| **Missing exec subcommand in older Sprite versions** | Medium - Feature unavailable | Detect `exec` support via error message; provide clear upgrade instructions |
+
+## Recommended Approach
+
+### Phase 1: Core Infrastructure (Foundation)
+
+1. **Add Error Handling** in `src/errors.ts`:
+   - Add `SPRITE_EXEC_FAILED` to `ErrorCodes` enum (lines 15-61)
+   - Create `SpriteExecError` class following `SpriteStartError` pattern (lines 429-437)
+   - Include `spriteName` and `command` in error context
+
+2. **Implement `execSprite()` Function** in `src/agent/sprite-runner.ts`:
+   - Add after `killSprite()` (after line 394)
+   - Follow `startSprite()` pattern (lines 253-288)
+   - Use `runWispCommand()` primitive with `["exec", name, ...command]` args
+   - Support optional `onStdoutChunk`/`onStderrChunk` callbacks for streaming
+   - Throw `SpriteExecError` on failure
+   - Return `WispResult` with exit code, stdout, stderr
+
+3. **Export New Function** in `src/agent/sprite-runner.ts`:
+   - Add `execSprite` to exports (after line 540)
+   - Update `runWispCommand()` to handle exec-specific errors if needed
+
+### Phase 2: CLI Integration (User Interface)
+
+4. **Add Command Options Interface** in `src/commands/sprite.ts`:
+   - Create `SpriteExecOptions` interface (after line 41)
+   - Include: `name: string`, `command: string[]`, `cwd?: string`, `json?: boolean`
+
+5. **Implement CLI Command** in `src/commands/sprite.ts`:
+   - Add `spriteExecCommand()` function (after line 375)
+   - Follow `spriteStartCommand()` pattern (lines 81-151)
+   - Load config via `getSpriteConfig()`
+   - Call `execSprite()` with options
+   - Handle success/error paths with emoji prefixes
+   - Support `--json` output with exit code included
+
+6. **Register CLI Command** in `src/index.ts`:
+   - Add subcommand after `sprite attach` (after line 558)
+   - Use `.command("exec <name> <command...>")` for variable argument capture
+   - Wire up global options and executeCommand wrapper
+   - Support `--json` flag
+
+### Phase 3: RLM Tool Integration (Agent Access)
+
+7. **Create RLM Tool** in `src/agent/rlm-tools.ts`:
+   - Add `ExecSpriteTool` constant (after line 450)
+   - Follow `SpawnSpriteTool` pattern (lines 244-301)
+   - Parameters: `name` (string), `command` (array of strings)
+   - Return JSON with `exitCode`, `stdout`, `stderr`
+   - Handle errors gracefully (catch, return JSON error)
+
+8. **Register Tool** in `src/agent/rlm-tools.ts`:
+   - Add `ExecSprite: ExecSpriteTool` to `ALL_TOOLS` registry (line 453)
+   - Include in `buildToolRegistry()` return value (line 467)
+
+### Phase 4: Testing & Polish (Quality Assurance)
+
+9. **Add Unit Tests** in `src/__tests__/commands/sprite.test.ts`:
+   - Add `describe("spriteExecCommand", ...)` block (after line 454)
+   - Test successful execution with mocked `spawn()`
+   - Test command execution failure (non-zero exit code)
+   - Test JSON output format
+   - Test error handling (Sprite not found, command not found)
+   - Test streaming output callbacks
+   - Test timeout handling
+
+10. **Documentation Updates**:
+    - Update `src/index.ts` command help text
+    - Add usage examples: `wreckit sprite exec my-vm -- npm install`
+    - Document exit code handling in JSON output
+    - Add troubleshooting for common exec failures
+
+11. **Integration Testing** (if Sprite CLI available):
+    - Test with real Sprite VM
+    - Verify command execution inside VM
+    - Test streaming output for long-running commands
+    - Verify exit code propagation
+    - Test with commands that produce large output
+
+## Open Questions
+
+1. **Sprite CLI `exec` Subcommand Interface**: What is the exact syntax for `sprite exec`?
+   - Is it `sprite exec <name> <command...>` or `sprite exec <name> -- <command>`?
+   - Does it require `--` separator to distinguish sprite flags from command flags?
+   - **Recommendation**: Test with actual Sprite CLI or review documentation; implement CLI command with `<command...>` variadic argument (no `--` separator) and adjust if needed
+
+2. **Output Streaming Behavior**: Should exec support streaming output to CLI?
+   - The existing `runWispCommand()` supports `onStdoutChunk`/`onStderrChunk` callbacks (lines 162-177)
+   - Should `wreckit sprite exec` stream output in real-time or buffer until completion?
+   - **Recommendation**: Default to buffer (existing pattern), but expose streaming option via `--stream` flag for future enhancement
+
+3. **Exit Code Handling**: How should non-zero exit codes be treated?
+   - Should they throw errors or return success=false with exit code in data?
+   - Existing pattern (lines 195-204) treats `code !== 0` as `success: false`
+   - **Recommendation**: Follow existing pattern: Return `success: false` with `exitCode` in JSON data; don't throw for non-zero exit codes (only for subprocess errors)
+
+4. **Working Directory Inside VM**: What directory does the command execute in?
+   - Sprite VM's home directory? Current directory of host? Configurable?
+   - Should we add `--cwd` option to specify working directory inside VM?
+   - **Recommendation**: Start with default (Sprite's home); add `--cwd` option later if needed
+
+5. **Interactive Commands**: How to handle commands requiring user input (e.g., `npm login`)?
+   - Should exec support stdin passthrough?
+   - Or explicitly document as non-interactive only?
+   - **Recommendation**: Explicitly document as non-interactive only; reject/timeout commands that try to read stdin
+
+6. **Command Array vs String**: Should CLI accept command as string or array?
+   - CLI: `wreckit sprite exec my-vm npm install` (array-like via variadic args)
+   - RLM Tool: `ExecSprite({ name: "my-vm", command: ["npm", "install"] })`
+   - **Recommendation**: CLI uses variadic args (converted to array internally), RLM tool requires array for safety (avoids shell injection)
+
+7. **Concurrent Exec Limits**: Should there be rate limiting on concurrent exec calls?
+   - Item 073 defines `maxVMs: 5` but no `maxConcurrentExecs`
+   - Risk of overwhelming a VM with multiple concurrent commands
+   - **Recommendation**: Document as user responsibility; add limits in future if issues arise
+
+8. **Large Output Handling**: What if command produces gigabytes of output?
+   - Buffering entire output could exhaust memory
+   - `runWispCommand()` accumulates stdout/stderr in strings (lines 99-100)
+   - **Recommendation**: Document memory limitation; implement streaming output via callbacks for production use
+
+## Implementation Notes
+
+- **Reuse `runWispCommand()` Primitive**: The core primitive at `src/agent/sprite-runner.ts:85-207` already handles subprocess spawning, timeout enforcement, output capture, and error detection. Simply pass `["exec", name, ...command]` as args.
+
+- **Follow Existing Error Patterns**: All Sprite operations use specific error classes (`SpriteStartError`, `SpriteAttachError`, `SpriteKillError`). Create `SpriteExecError` following the same pattern for consistency.
+
+- **Support Streaming Output**: The `onStdoutChunk` and `onStderrChunk` callbacks (lines 46-49, 162-177) enable real-time output streaming. Expose these in the `execSprite()` signature for RLM tools that need streaming.
+
+- **Respect Timeouts**: The `config.timeout` (default 300s) applies to exec operations. Long-running commands (e.g., `npm install`) may need increased timeout via config.
+
+- **Exit Code Semantics**: Distinguish between subprocess errors (spawn failure, timeout) and command failure (non-zero exit code). Subprocess errors throw; command failures return `success: false` with exit code.
+
+- **CLI Variadic Arguments**: Commander.js `.command("exec <name> <command...>")` captures all arguments after `<name>` into an array. Pass this array directly to `execSprite()` without shell interpolation.
+
+- **RLM Tool Safety**: RLM tool requires command as array (not string) to avoid shell injection vulnerabilities. Array form of `spawn()` doesn't invoke shell, preventing `; rm -rf` style attacks.
+
+- **Authentication**: Token already injected via environment variable (lines 91-96). No additional auth handling needed for exec.
+
+- **Testing**: Mock `spawn()` using existing test helpers (`mockSpawnSuccess`, `mockSpawnFailure`). Test with realistic stdout/stderr to verify output capture.
+
+- **Backward Compatibility**: Adding `exec` doesn't break existing Sprite functionality (start/attach/list/kill). No migration needed.
+
+- **Documentation**: Update SPRITE_USAGE.md (from Item 073) to include exec examples and troubleshooting.

--- a/src/__tests__/agent.test.ts
+++ b/src/__tests__/agent.test.ts
@@ -109,7 +109,10 @@ describe("getAgentConfigUnion", () => {
     expect(result.kind).toBe("process");
     if (result.kind === "process") {
       expect(result.command).toBe("claude");
-      expect(result.args).toEqual(["--dangerously-skip-permissions", "--print"]);
+      expect(result.args).toEqual([
+        "--dangerously-skip-permissions",
+        "--print",
+      ]);
       expect(result.completion_signal).toBe("FINISHED");
     }
   });

--- a/src/__tests__/commands/orchestrator.test.ts
+++ b/src/__tests__/commands/orchestrator.test.ts
@@ -19,8 +19,9 @@ mock.module("../../commands/run", () => ({
   runCommand: mockedRunCommand,
 }));
 
-const { orchestrateAll, orchestrateNext, getNextIncompleteItem } =
-  await import("../../commands/orchestrator");
+const { orchestrateAll, orchestrateNext, getNextIncompleteItem } = await import(
+  "../../commands/orchestrator"
+);
 
 function createMockLogger(): Logger {
   return {

--- a/src/__tests__/edge-cases/branch-ops.isospec.ts
+++ b/src/__tests__/edge-cases/branch-ops.isospec.ts
@@ -13,8 +13,9 @@ mock.module("node:child_process", () => ({
   spawn: mockedSpawn,
 }));
 
-const { getCurrentBranch, branchExists, ensureBranch } =
-  await import("../../git");
+const { getCurrentBranch, branchExists, ensureBranch } = await import(
+  "../../git"
+);
 
 function createMockLogger(): Logger {
   return {

--- a/src/__tests__/edge-cases/errors.isospec.ts
+++ b/src/__tests__/edge-cases/errors.isospec.ts
@@ -14,7 +14,11 @@ import type { Logger } from "../../logging";
 import { RepoNotFoundError } from "../../errors";
 
 import * as childProcess from "node:child_process";
-import { runAgentUnion, type AgentConfigUnion, type UnionRunAgentOptions } from "../../agent";
+import {
+  runAgentUnion,
+  type AgentConfigUnion,
+  type UnionRunAgentOptions,
+} from "../../agent";
 import { pushBranch, getPrByBranch, type GitOptions } from "../../git";
 import { findRepoRoot } from "../../fs";
 

--- a/src/__tests__/edge-cases/mock-agent.isospec.ts
+++ b/src/__tests__/edge-cases/mock-agent.isospec.ts
@@ -2,7 +2,11 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import * as os from "node:os";
-import { runAgentUnion, type AgentConfigUnion, type UnionRunAgentOptions } from "../../agent";
+import {
+  runAgentUnion,
+  type AgentConfigUnion,
+  type UnionRunAgentOptions,
+} from "../../agent";
 import type { Logger } from "../../logging";
 
 function createMockLogger(): Logger {

--- a/src/__tests__/env-check.test.ts
+++ b/src/__tests__/env-check.test.ts
@@ -1,4 +1,3 @@
-
 import { describe, expect, it } from "bun:test";
 
 describe("Environment Check", () => {
@@ -10,7 +9,9 @@ describe("Environment Check", () => {
       console.log("ZAI_API_KEY is MISSING.");
     }
     // Check other keys
-    if (process.env.ANTHROPIC_API_KEY) console.log("ANTHROPIC_API_KEY is present.");
-    if (process.env.ANTHROPIC_AUTH_TOKEN) console.log("ANTHROPIC_AUTH_TOKEN is present.");
+    if (process.env.ANTHROPIC_API_KEY)
+      console.log("ANTHROPIC_API_KEY is present.");
+    if (process.env.ANTHROPIC_AUTH_TOKEN)
+      console.log("ANTHROPIC_AUTH_TOKEN is present.");
   });
 });

--- a/src/__tests__/opencode-sdk-runner.test.ts
+++ b/src/__tests__/opencode-sdk-runner.test.ts
@@ -28,8 +28,9 @@ describe("runOpenCodeSdkAgent", () => {
 
   describe("dry-run mode", () => {
     it("returns success without calling SDK", async () => {
-      const { runOpenCodeSdkAgent } =
-        await import("../agent/opencode-sdk-runner");
+      const { runOpenCodeSdkAgent } = await import(
+        "../agent/opencode-sdk-runner"
+      );
       const result = await runOpenCodeSdkAgent({
         config: createDefaultConfig(),
         cwd: "/tmp/test",
@@ -44,8 +45,9 @@ describe("runOpenCodeSdkAgent", () => {
     });
 
     it("logs tool restrictions when allowedTools provided", async () => {
-      const { runOpenCodeSdkAgent } =
-        await import("../agent/opencode-sdk-runner");
+      const { runOpenCodeSdkAgent } = await import(
+        "../agent/opencode-sdk-runner"
+      );
       const result = await runOpenCodeSdkAgent({
         config: createDefaultConfig(),
         cwd: "/tmp/test",
@@ -66,8 +68,9 @@ describe("runOpenCodeSdkAgent", () => {
 
   describe("getEffectiveToolAllowlist resolution", () => {
     it("prefers explicit allowedTools over phase", async () => {
-      const { runOpenCodeSdkAgent } =
-        await import("../agent/opencode-sdk-runner");
+      const { runOpenCodeSdkAgent } = await import(
+        "../agent/opencode-sdk-runner"
+      );
       const result = await runOpenCodeSdkAgent({
         config: createDefaultConfig(),
         cwd: "/tmp/test",
@@ -89,8 +92,9 @@ describe("runOpenCodeSdkAgent", () => {
     });
 
     it("falls back to phase-based allowlist when no explicit tools", async () => {
-      const { runOpenCodeSdkAgent } =
-        await import("../agent/opencode-sdk-runner");
+      const { runOpenCodeSdkAgent } = await import(
+        "../agent/opencode-sdk-runner"
+      );
       const result = await runOpenCodeSdkAgent({
         config: createDefaultConfig(),
         cwd: "/tmp/test",
@@ -111,8 +115,9 @@ describe("runOpenCodeSdkAgent", () => {
     });
 
     it("has no restrictions when neither allowedTools nor phase specified", async () => {
-      const { runOpenCodeSdkAgent } =
-        await import("../agent/opencode-sdk-runner");
+      const { runOpenCodeSdkAgent } = await import(
+        "../agent/opencode-sdk-runner"
+      );
       const result = await runOpenCodeSdkAgent({
         config: createDefaultConfig(),
         cwd: "/tmp/test",

--- a/src/agent/__tests__/rlm-integration.test.ts
+++ b/src/agent/__tests__/rlm-integration.test.ts
@@ -46,7 +46,7 @@ describe("RLM Agent Integration", () => {
     });
 
     expect(result.success).toBe(true);
-    
+
     // Verify side effects
     const content = await fs.readFile(testFile, "utf-8");
     expect(content).toBe("Hello RLM");
@@ -75,7 +75,7 @@ describe("RLM Agent Integration", () => {
     // Since we can't easily spy on internal tools here, we rely on the agent's output
     // indicating it couldn't perform the action or tried another way.
     // Ideally, the tool registry filters it out so the model doesn't even see it.
-    
+
     expect(result.success).toBe(true); // Agent should handle the restriction gracefully
     expect(result.output).not.toContain("Stdout:"); // Should not have executed bash
   }, 30000);

--- a/src/agent/__tests__/rlm-runner.test.ts
+++ b/src/agent/__tests__/rlm-runner.test.ts
@@ -71,7 +71,7 @@ describe("runRlmAgent", () => {
     expect(result.success).toBe(true);
     // Verify environment setup in a real unit test would require mocking buildAxAIEnv
     // For now we just ensure it doesn't crash
-    
+
     process.env = originalEnv;
   });
 

--- a/src/agent/claude-sdk-runner.ts
+++ b/src/agent/claude-sdk-runner.ts
@@ -21,8 +21,18 @@ export interface ClaudeRunAgentOptions {
   timeoutSeconds?: number;
 }
 
-export async function runClaudeSdkAgent(options: ClaudeRunAgentOptions): Promise<AgentResult> {
-  const { config, cwd, prompt, logger, onStdoutChunk, onStderrChunk, onAgentEvent } = options;
+export async function runClaudeSdkAgent(
+  options: ClaudeRunAgentOptions,
+): Promise<AgentResult> {
+  const {
+    config,
+    cwd,
+    prompt,
+    logger,
+    onStdoutChunk,
+    onStderrChunk,
+    onAgentEvent,
+  } = options;
   const timeoutSeconds = options.timeoutSeconds ?? 3600;
   let output = "";
   let timedOut = false;
@@ -80,7 +90,9 @@ export async function runClaudeSdkAgent(options: ClaudeRunAgentOptions): Promise
       }
 
       // Route to appropriate callback based on message type
-      const isError = message.type === "error" || message.constructor?.name === "ErrorMessage";
+      const isError =
+        message.type === "error" ||
+        message.constructor?.name === "ErrorMessage";
 
       if (messageText) {
         if (isError) {
@@ -136,7 +148,11 @@ export async function runClaudeSdkAgent(options: ClaudeRunAgentOptions): Promise
   }
 }
 
-function handleSdkError(error: any, output: string, logger: Logger): { success: boolean; output: string; exitCode: number | null } {
+function handleSdkError(
+  error: any,
+  output: string,
+  logger: Logger,
+): { success: boolean; output: string; exitCode: number | null } {
   const errorMessage = error instanceof Error ? error.message : String(error);
   const errorStack = error instanceof Error ? error.stack : undefined;
 
@@ -205,7 +221,9 @@ Run 'wreckit sdk-info' to diagnose your current credential configuration.
   ) {
     return {
       success: false,
-      output: output + `\n⚠️ Rate limit exceeded: ${errorMessage}\n\nPlease try again later.\n`,
+      output:
+        output +
+        `\n⚠️ Rate limit exceeded: ${errorMessage}\n\nPlease try again later.\n`,
       exitCode: 1,
     };
   }
@@ -219,7 +237,9 @@ Run 'wreckit sdk-info' to diagnose your current credential configuration.
   ) {
     return {
       success: false,
-      output: output + `\n❌ Context error: ${errorMessage}\n\nTry breaking down the task into smaller pieces or reducing the scope.\n`,
+      output:
+        output +
+        `\n❌ Context error: ${errorMessage}\n\nTry breaking down the task into smaller pieces or reducing the scope.\n`,
       exitCode: 1,
     };
   }
@@ -233,7 +253,9 @@ Run 'wreckit sdk-info' to diagnose your current credential configuration.
   ) {
     return {
       success: false,
-      output: output + `\n❌ Network error: ${errorMessage}\n\nPlease check your internet connection and try again.\n`,
+      output:
+        output +
+        `\n❌ Network error: ${errorMessage}\n\nPlease check your internet connection and try again.\n`,
       exitCode: 1,
     };
   }
@@ -250,15 +272,19 @@ function formatSdkMessage(message: any): string {
   // Handle assistant messages (Claude's reasoning and tool calls)
   if (message.type === "assistant") {
     const content = message.message?.content || message.content || [];
-    return content.map((block: any) => {
-      if (block.type === "text") return block.text;
-      if (block.type === "tool_use") {
-        const toolName = block.name;
-        const toolInput = JSON.stringify(block.input, null, 2);
-        return `\n\`\`\`tool\n${toolName}\n${toolInput}\n\`\`\`\n`;
-      }
-      return "";
-    }).join("\n") || "";
+    return (
+      content
+        .map((block: any) => {
+          if (block.type === "text") return block.text;
+          if (block.type === "tool_use") {
+            const toolName = block.name;
+            const toolInput = JSON.stringify(block.input, null, 2);
+            return `\n\`\`\`tool\n${toolName}\n${toolInput}\n\`\`\`\n`;
+          }
+          return "";
+        })
+        .join("\n") || ""
+    );
   }
 
   // Handle tool result messages
@@ -281,7 +307,10 @@ function formatSdkMessage(message: any): string {
   return "";
 }
 
-function emitAgentEventsFromSdkMessage(message: any, emit: (event: AgentEvent) => void): void {
+function emitAgentEventsFromSdkMessage(
+  message: any,
+  emit: (event: AgentEvent) => void,
+): void {
   // Handle assistant messages (Claude's reasoning and tool calls)
   if (message.type === "assistant") {
     const content = message.message?.content || message.content || [];
@@ -304,7 +333,10 @@ function emitAgentEventsFromSdkMessage(message: any, emit: (event: AgentEvent) =
   }
 
   // Handle tool result messages
-  if (message.type === "tool_result" || message.constructor?.name === "ToolResultMessage") {
+  if (
+    message.type === "tool_result" ||
+    message.constructor?.name === "ToolResultMessage"
+  ) {
     const result = message.result ?? message.content ?? "";
     const toolUseId = message.tool_use_id || "";
     emit({ type: "tool_result", toolUseId, result });
@@ -312,13 +344,19 @@ function emitAgentEventsFromSdkMessage(message: any, emit: (event: AgentEvent) =
   }
 
   // Handle final result messages
-  if (message.type === "result" || message.constructor?.name === "ResultMessage") {
+  if (
+    message.type === "result" ||
+    message.constructor?.name === "ResultMessage"
+  ) {
     emit({ type: "run_result", subtype: message.subtype });
     return;
   }
 
   // Handle error messages
-  if (message.type === "error" || message.constructor?.name === "ErrorMessage") {
+  if (
+    message.type === "error" ||
+    message.constructor?.name === "ErrorMessage"
+  ) {
     emit({ type: "error", message: message.message || String(message) });
     return;
   }

--- a/src/agent/dispatcher.ts
+++ b/src/agent/dispatcher.ts
@@ -1,5 +1,14 @@
 import type { Logger } from "../logging";
-import type { AgentConfigUnion, ProcessAgentConfig, ClaudeSdkAgentConfig, AmpSdkAgentConfig, CodexSdkAgentConfig, OpenCodeSdkAgentConfig, RlmSdkAgentConfig, SpriteAgentConfig } from "../schemas";
+import type {
+  AgentConfigUnion,
+  ProcessAgentConfig,
+  ClaudeSdkAgentConfig,
+  AmpSdkAgentConfig,
+  CodexSdkAgentConfig,
+  OpenCodeSdkAgentConfig,
+  RlmSdkAgentConfig,
+  SpriteAgentConfig,
+} from "../schemas";
 import type { AgentEvent } from "../tui/agentEvents";
 import { runProcessAgent } from "./process-runner.js";
 import type { AgentResult } from "./result";
@@ -18,7 +27,7 @@ function exhaustiveCheck(x: never): never {
  */
 export async function dispatchAgent(
   config: AgentConfigUnion,
-  options: CommonRunAgentOptions
+  options: CommonRunAgentOptions,
 ): Promise<AgentResult> {
   const { logger, dryRun = false, mockAgent = false } = options;
 

--- a/src/agent/env.ts
+++ b/src/agent/env.ts
@@ -20,7 +20,7 @@ const ALLOWED_PREFIXES = [
   "OPENAI_",
   "GOOGLE_",
   "ZAI_",
-  "SPRITES_"
+  "SPRITES_",
 ];
 
 /**
@@ -140,7 +140,9 @@ export interface BuildAxAIEnvOptions extends BuildSdkEnvOptions {
 /**
  * Build environment specifically for AxAI providers.
  */
-export async function buildAxAIEnv(options: BuildAxAIEnvOptions): Promise<Record<string, string>> {
+export async function buildAxAIEnv(
+  options: BuildAxAIEnvOptions,
+): Promise<Record<string, string>> {
   const { provider, logger } = options;
   const baseEnv = await buildSdkEnv(options);
   const axaiEnv: Record<string, string> = { ...baseEnv };
@@ -159,7 +161,7 @@ export async function buildAxAIEnv(options: BuildAxAIEnvOptions): Promise<Record
     } else if (axaiEnv.ANTHROPIC_AUTH_TOKEN) {
       axaiEnv.ANTHROPIC_API_KEY = axaiEnv.ANTHROPIC_AUTH_TOKEN;
     }
-    
+
     // 2. Set default base URL for Z.AI if not already set (via ANTHROPIC_BASE_URL)
     if (!axaiEnv.ANTHROPIC_BASE_URL) {
       axaiEnv.ANTHROPIC_BASE_URL = "https://api.z.ai/api/anthropic";
@@ -188,7 +190,9 @@ export interface BuildSpriteEnvOptions extends BuildSdkEnvOptions {
  * Build environment specifically for Sprite CLI operations.
  * Handles Sprites.dev authentication token.
  */
-export async function buildSpriteEnv(options: BuildSpriteEnvOptions): Promise<Record<string, string>> {
+export async function buildSpriteEnv(
+  options: BuildSpriteEnvOptions,
+): Promise<Record<string, string>> {
   const { token, logger } = options;
   const baseEnv = await buildSdkEnv(options);
   const spriteEnv: Record<string, string> = { ...baseEnv };

--- a/src/agent/process-runner.ts
+++ b/src/agent/process-runner.ts
@@ -67,7 +67,7 @@ export interface ProcessRunnerOptions {
  */
 export async function runProcessAgent(
   config: ProcessAgentConfig,
-  options: ProcessRunnerOptions
+  options: ProcessRunnerOptions,
 ): Promise<AgentResult> {
   const { cwd, prompt, logger } = options;
   const timeoutSeconds = options.timeoutSeconds ?? 3600;
@@ -164,7 +164,9 @@ export async function runProcessAgent(
       unregisterProcessAgent(child);
       if (timeoutId) clearTimeout(timeoutId);
       const success = code === 0 && completionDetected;
-      logger.debug(`Agent exited with code ${code}, completion detected: ${completionDetected}`);
+      logger.debug(
+        `Agent exited with code ${code}, completion detected: ${completionDetected}`,
+      );
       resolve({
         success,
         output,

--- a/src/agent/rlm-tools.ts
+++ b/src/agent/rlm-tools.ts
@@ -26,9 +26,11 @@ export class JSRuntime {
   private logs: string[] = [];
 
   private log(level: string, ...args: any[]) {
-    this.logs.push(`[${level}] ${args.map(a => 
-      typeof a === 'object' ? JSON.stringify(a) : String(a)
-    ).join(" ")}`);
+    this.logs.push(
+      `[${level}] ${args
+        .map((a) => (typeof a === "object" ? JSON.stringify(a) : String(a)))
+        .join(" ")}`,
+    );
   }
 
   run(code: string): string {
@@ -47,7 +49,8 @@ export class JSRuntime {
 export function createRunJSTool(runtime: JSRuntime): AxFunction {
   return {
     name: "RunJS",
-    description: "Execute JavaScript code to process data. Access the global variable 'CONTEXT_DATA' to see the user's input.",
+    description:
+      "Execute JavaScript code to process data. Access the global variable 'CONTEXT_DATA' to see the user's input.",
     parameters: {
       type: "object",
       properties: {
@@ -83,7 +86,8 @@ const ReadTool: AxFunction = {
 
 const WriteTool: AxFunction = {
   name: "Write",
-  description: "Write content to a file. Creates parent directories if they don't exist.",
+  description:
+    "Write content to a file. Creates parent directories if they don't exist.",
   parameters: {
     type: "object",
     properties: {
@@ -92,7 +96,13 @@ const WriteTool: AxFunction = {
     },
     required: ["path", "content"],
   } as AxFunctionJSONSchema,
-  func: async ({ path: filePath, content }: { path: string; content: string }) => {
+  func: async ({
+    path: filePath,
+    content,
+  }: {
+    path: string;
+    content: string;
+  }) => {
     try {
       await fs.mkdir(path.dirname(filePath), { recursive: true });
       await fs.writeFile(filePath, content, "utf-8");
@@ -105,7 +115,8 @@ const WriteTool: AxFunction = {
 
 const EditTool: AxFunction = {
   name: "Edit",
-  description: "Edit a file by replacing a string with a new string. Returns success message or error.",
+  description:
+    "Edit a file by replacing a string with a new string. Returns success message or error.",
   parameters: {
     type: "object",
     properties: {
@@ -115,7 +126,15 @@ const EditTool: AxFunction = {
     },
     required: ["path", "oldText", "newText"],
   } as AxFunctionJSONSchema,
-  func: async ({ path: filePath, oldText, newText }: { path: string; oldText: string; newText: string }) => {
+  func: async ({
+    path: filePath,
+    oldText,
+    newText,
+  }: {
+    path: string;
+    oldText: string;
+    newText: string;
+  }) => {
     try {
       const content = await fs.readFile(filePath, "utf-8");
       if (!content.includes(oldText)) {
@@ -136,12 +155,24 @@ const GlobTool: AxFunction = {
   parameters: {
     type: "object",
     properties: {
-      pattern: { type: "string", description: "The glob pattern (e.g., '**/*.ts')" },
-      path: { type: "string", description: "The directory to search in (default: current directory)" },
+      pattern: {
+        type: "string",
+        description: "The glob pattern (e.g., '**/*.ts')",
+      },
+      path: {
+        type: "string",
+        description: "The directory to search in (default: current directory)",
+      },
     },
     required: ["pattern"],
   } as AxFunctionJSONSchema,
-  func: async ({ pattern, path: searchPath }: { pattern: string; path?: string }) => {
+  func: async ({
+    pattern,
+    path: searchPath,
+  }: {
+    pattern: string;
+    path?: string;
+  }) => {
     try {
       // Using 'find' as a fallback since fast-glob might not be available
       // Note: This is a simplified implementation and might not support all glob features
@@ -160,17 +191,36 @@ const GrepTool: AxFunction = {
   parameters: {
     type: "object",
     properties: {
-      pattern: { type: "string", description: "The regex pattern to search for" },
-      path: { type: "string", description: "The directory to search in (default: current directory)" },
-      include: { type: "string", description: "File pattern to include (e.g., '*.ts')" },
+      pattern: {
+        type: "string",
+        description: "The regex pattern to search for",
+      },
+      path: {
+        type: "string",
+        description: "The directory to search in (default: current directory)",
+      },
+      include: {
+        type: "string",
+        description: "File pattern to include (e.g., '*.ts')",
+      },
     },
     required: ["pattern"],
   } as AxFunctionJSONSchema,
-  func: async ({ pattern, path: searchPath, include }: { pattern: string; path?: string; include?: string }) => {
+  func: async ({
+    pattern,
+    path: searchPath,
+    include,
+  }: {
+    pattern: string;
+    path?: string;
+    include?: string;
+  }) => {
     try {
       const dir = searchPath || ".";
       const includeFlag = include ? `--include=\"${include}\"` : "";
-      const { stdout } = await execAsync(`grep -r ${includeFlag} "${pattern}" ${dir}`);
+      const { stdout } = await execAsync(
+        `grep -r ${includeFlag} "${pattern}" ${dir}`,
+      );
       return stdout.trim() || "No matches found";
     } catch (error: any) {
       // grep returns exit code 1 if no matches found, which execAsync throws as error
@@ -228,10 +278,14 @@ const spriteLogger: {
   error: (msg: string, ...args: unknown[]) => void;
   json: (data: unknown) => void;
 } = {
-  debug: (msg: string, ...args: unknown[]) => console.debug(`[Sprite] ${msg}`, ...args),
-  info: (msg: string, ...args: unknown[]) => console.info(`[Sprite] ${msg}`, ...args),
-  warn: (msg: string, ...args: unknown[]) => console.warn(`[Sprite] ${msg}`, ...args),
-  error: (msg: string, ...args: unknown[]) => console.error(`[Sprite] ${msg}`, ...args),
+  debug: (msg: string, ...args: unknown[]) =>
+    console.debug(`[Sprite] ${msg}`, ...args),
+  info: (msg: string, ...args: unknown[]) =>
+    console.info(`[Sprite] ${msg}`, ...args),
+  warn: (msg: string, ...args: unknown[]) =>
+    console.warn(`[Sprite] ${msg}`, ...args),
+  error: (msg: string, ...args: unknown[]) =>
+    console.error(`[Sprite] ${msg}`, ...args),
   json: (data: unknown) => console.log(JSON.stringify(data, null, 2)),
 };
 
@@ -243,7 +297,8 @@ const spriteLogger: {
  */
 const SpawnSpriteTool: AxFunction = {
   name: "SpawnSprite",
-  description: "Start a new Sprite VM (Firecracker microVM) for isolated, sandboxed execution. Returns connection info for the new VM.",
+  description:
+    "Start a new Sprite VM (Firecracker microVM) for isolated, sandboxed execution. Returns connection info for the new VM.",
   parameters: {
     type: "object",
     properties: {
@@ -253,7 +308,8 @@ const SpawnSpriteTool: AxFunction = {
       },
       memory: {
         type: "string",
-        description: "Memory allocation for the VM (e.g., '512MiB', '1GiB'). Default: '512MiB'",
+        description:
+          "Memory allocation for the VM (e.g., '512MiB', '1GiB'). Default: '512MiB'",
       },
       cpus: {
         type: "string",
@@ -262,7 +318,15 @@ const SpawnSpriteTool: AxFunction = {
     },
     required: ["name"],
   } as AxFunctionJSONSchema,
-  func: async ({ name, memory, cpus }: { name: string; memory?: string; cpus?: string }) => {
+  func: async ({
+    name,
+    memory,
+    cpus,
+  }: {
+    name: string;
+    memory?: string;
+    cpus?: string;
+  }) => {
     try {
       // Dynamic import to avoid circular dependency
       const { startSprite } = await import("./sprite-runner.js");
@@ -276,27 +340,39 @@ const SpawnSpriteTool: AxFunction = {
       const result = await startSprite(name, config, spriteLogger);
 
       if (result.success) {
-        return JSON.stringify({
-          success: true,
-          message: `Started Sprite '${name}'`,
-          data: {
-            name,
-            stdout: result.stdout,
-            stderr: result.stderr,
+        return JSON.stringify(
+          {
+            success: true,
+            message: `Started Sprite '${name}'`,
+            data: {
+              name,
+              stdout: result.stdout,
+              stderr: result.stderr,
+            },
           },
-        }, null, 2);
+          null,
+          2,
+        );
       } else {
-        return JSON.stringify({
-          success: false,
-          error: result.stderr || result.error || "Failed to start Sprite",
-        }, null, 2);
+        return JSON.stringify(
+          {
+            success: false,
+            error: result.stderr || result.error || "Failed to start Sprite",
+          },
+          null,
+          2,
+        );
       }
     } catch (error: any) {
       // Catch and return errors in JSON format (don't throw)
-      return JSON.stringify({
-        success: false,
-        error: error.message || "Unknown error starting Sprite",
-      }, null, 2);
+      return JSON.stringify(
+        {
+          success: false,
+          error: error.message || "Unknown error starting Sprite",
+        },
+        null,
+        2,
+      );
     }
   },
 };
@@ -309,7 +385,8 @@ const SpawnSpriteTool: AxFunction = {
  */
 const AttachSpriteTool: AxFunction = {
   name: "AttachSprite",
-  description: "Attach to a running Sprite VM. Returns console output from the VM.",
+  description:
+    "Attach to a running Sprite VM. Returns console output from the VM.",
   parameters: {
     type: "object",
     properties: {
@@ -325,30 +402,47 @@ const AttachSpriteTool: AxFunction = {
       // Dynamic import to avoid circular dependency
       const { attachSprite } = await import("./sprite-runner.js");
 
-      const result = await attachSprite(name, DEFAULT_SPRITE_CONFIG, spriteLogger);
+      const result = await attachSprite(
+        name,
+        DEFAULT_SPRITE_CONFIG,
+        spriteLogger,
+      );
 
       if (result.success) {
-        return JSON.stringify({
-          success: true,
-          message: `Attached to Sprite '${name}'`,
-          data: {
-            name,
-            stdout: result.stdout,
-            stderr: result.stderr,
+        return JSON.stringify(
+          {
+            success: true,
+            message: `Attached to Sprite '${name}'`,
+            data: {
+              name,
+              stdout: result.stdout,
+              stderr: result.stderr,
+            },
           },
-        }, null, 2);
+          null,
+          2,
+        );
       } else {
-        return JSON.stringify({
-          success: false,
-          error: result.stderr || result.error || "Failed to attach to Sprite",
-        }, null, 2);
+        return JSON.stringify(
+          {
+            success: false,
+            error:
+              result.stderr || result.error || "Failed to attach to Sprite",
+          },
+          null,
+          2,
+        );
       }
     } catch (error: any) {
       // Catch and return errors in JSON format (don't throw)
-      return JSON.stringify({
-        success: false,
-        error: error.message || "Unknown error attaching to Sprite",
-      }, null, 2);
+      return JSON.stringify(
+        {
+          success: false,
+          error: error.message || "Unknown error attaching to Sprite",
+        },
+        null,
+        2,
+      );
     }
   },
 };
@@ -360,7 +454,8 @@ const AttachSpriteTool: AxFunction = {
  */
 const ListSpritesTool: AxFunction = {
   name: "ListSprites",
-  description: "List all active Sprite VMs. Returns a JSON array with Sprite information (ID, state, PID, etc.).",
+  description:
+    "List all active Sprite VMs. Returns a JSON array with Sprite information (ID, state, PID, etc.).",
   parameters: {
     type: "object",
     properties: {},
@@ -375,26 +470,38 @@ const ListSpritesTool: AxFunction = {
 
       if (result.success) {
         const sprites = parseWispJson(result.stdout, spriteLogger);
-        return JSON.stringify({
-          success: true,
-          message: `Active Sprites: ${Array.isArray(sprites) ? sprites.length : 0}`,
-          data: {
-            sprites: sprites || [],
-            rawOutput: result.stdout,
+        return JSON.stringify(
+          {
+            success: true,
+            message: `Active Sprites: ${Array.isArray(sprites) ? sprites.length : 0}`,
+            data: {
+              sprites: sprites || [],
+              rawOutput: result.stdout,
+            },
           },
-        }, null, 2);
+          null,
+          2,
+        );
       } else {
-        return JSON.stringify({
-          success: false,
-          error: result.stderr || result.error || "Failed to list Sprites",
-        }, null, 2);
+        return JSON.stringify(
+          {
+            success: false,
+            error: result.stderr || result.error || "Failed to list Sprites",
+          },
+          null,
+          2,
+        );
       }
     } catch (error: any) {
       // Catch and return errors in JSON format (don't throw)
-      return JSON.stringify({
-        success: false,
-        error: error.message || "Unknown error listing Sprites",
-      }, null, 2);
+      return JSON.stringify(
+        {
+          success: false,
+          error: error.message || "Unknown error listing Sprites",
+        },
+        null,
+        2,
+      );
     }
   },
 };
@@ -422,30 +529,133 @@ const KillSpriteTool: AxFunction = {
       // Dynamic import to avoid circular dependency
       const { killSprite } = await import("./sprite-runner.js");
 
-      const result = await killSprite(name, DEFAULT_SPRITE_CONFIG, spriteLogger);
+      const result = await killSprite(
+        name,
+        DEFAULT_SPRITE_CONFIG,
+        spriteLogger,
+      );
 
       if (result.success) {
-        return JSON.stringify({
-          success: true,
-          message: `Killed Sprite '${name}'`,
-          data: {
-            name,
-            stdout: result.stdout,
-            stderr: result.stderr,
+        return JSON.stringify(
+          {
+            success: true,
+            message: `Killed Sprite '${name}'`,
+            data: {
+              name,
+              stdout: result.stdout,
+              stderr: result.stderr,
+            },
           },
-        }, null, 2);
+          null,
+          2,
+        );
       } else {
-        return JSON.stringify({
-          success: false,
-          error: result.stderr || result.error || "Failed to kill Sprite",
-        }, null, 2);
+        return JSON.stringify(
+          {
+            success: false,
+            error: result.stderr || result.error || "Failed to kill Sprite",
+          },
+          null,
+          2,
+        );
       }
     } catch (error: any) {
       // Catch and return errors in JSON format (don't throw)
-      return JSON.stringify({
-        success: false,
-        error: error.message || "Unknown error killing Sprite",
-      }, null, 2);
+      return JSON.stringify(
+        {
+          success: false,
+          error: error.message || "Unknown error killing Sprite",
+        },
+        null,
+        2,
+      );
+    }
+  },
+};
+
+/**
+ * ExecSpriteTool - Execute a command inside a running Sprite VM.
+ *
+ * This tool allows RLM agents to run arbitrary commands inside Sprite VMs,
+ * enabling them to perform work (clone, build, test) inside the sandbox.
+ */
+const ExecSpriteTool: AxFunction = {
+  name: "ExecSprite",
+  description:
+    "Execute a command inside a running Sprite VM. Returns command output and exit code.",
+  parameters: {
+    type: "object",
+    properties: {
+      name: {
+        type: "string",
+        description: "Name/ID of the Sprite VM to execute command in",
+      },
+      command: {
+        type: "array",
+        items: { type: "string" },
+        description:
+          "Command and arguments to execute (e.g., ['npm', 'install'])",
+      },
+    },
+    required: ["name", "command"],
+  } as AxFunctionJSONSchema,
+  func: async ({ name, command }: { name: string; command: string[] }) => {
+    try {
+      // Dynamic import to avoid circular dependency
+      const { execSprite } = await import("./sprite-runner.js");
+
+      const result = await execSprite(
+        name,
+        command,
+        DEFAULT_SPRITE_CONFIG,
+        spriteLogger,
+      );
+
+      if (result.success) {
+        return JSON.stringify(
+          {
+            success: true,
+            message: `Executed command in Sprite '${name}'`,
+            data: {
+              name,
+              command,
+              exitCode: result.exitCode,
+              stdout: result.stdout,
+              stderr: result.stderr,
+            },
+          },
+          null,
+          2,
+        );
+      } else {
+        // Command failed (non-zero exit code) - return failure with exit code
+        return JSON.stringify(
+          {
+            success: false,
+            message: `Command failed with exit code ${result.exitCode}`,
+            error: result.stderr || result.error || "Command execution failed",
+            data: {
+              name,
+              command,
+              exitCode: result.exitCode,
+              stdout: result.stdout,
+              stderr: result.stderr,
+            },
+          },
+          null,
+          2,
+        );
+      }
+    } catch (error: any) {
+      // Catch and return errors in JSON format (don't throw)
+      return JSON.stringify(
+        {
+          success: false,
+          error: error.message || "Unknown error executing command",
+        },
+        null,
+        2,
+      );
     }
   },
 };
@@ -462,9 +672,13 @@ const ALL_TOOLS: ToolRegistry = {
   AttachSprite: AttachSpriteTool,
   ListSprites: ListSpritesTool,
   KillSprite: KillSpriteTool,
+  ExecSprite: ExecSpriteTool,
 };
 
-export function buildToolRegistry(allowedTools?: string[], jsRuntime?: JSRuntime): AxFunction[] {
+export function buildToolRegistry(
+  allowedTools?: string[],
+  jsRuntime?: JSRuntime,
+): AxFunction[] {
   let tools = allowedTools
     ? allowedTools
         .map((name) => ALL_TOOLS[name])
@@ -474,10 +688,10 @@ export function buildToolRegistry(allowedTools?: string[], jsRuntime?: JSRuntime
   // If a JS runtime is provided, always add the RunJS tool (it's the core RLM mechanic)
   // But we respect allowlists if "RunJS" is explicitly excluded (which it won't be in most cases)
   if (jsRuntime) {
-     const runJsTool = createRunJSTool(jsRuntime);
-     if (!allowedTools || allowedTools.includes("RunJS")) {
-        tools.push(runJsTool);
-     }
+    const runJsTool = createRunJSTool(jsRuntime);
+    if (!allowedTools || allowedTools.includes("RunJS")) {
+      tools.push(runJsTool);
+    }
   }
 
   return tools;

--- a/src/agent/runner.ts
+++ b/src/agent/runner.ts
@@ -1,7 +1,11 @@
 import type { ConfigResolved } from "../config";
 import type { Logger } from "../logging";
 import type { AgentEvent } from "../tui/agentEvents";
-import type { AgentConfigUnion, ProcessAgentConfig, ClaudeSdkAgentConfig } from "../schemas";
+import type {
+  AgentConfigUnion,
+  ProcessAgentConfig,
+  ClaudeSdkAgentConfig,
+} from "../schemas";
 
 // ============================================================
 // Lifecycle Management (Re-exported from lifecycle module)
@@ -123,11 +127,23 @@ function exhaustiveCheck(x: never): never {
  * });
  * ```
  */
-export async function runAgentUnion(options: UnionRunAgentOptions): Promise<AgentResult> {
-  const { config, logger, dryRun = false, mockAgent = false, cwd, prompt } = options;
+export async function runAgentUnion(
+  options: UnionRunAgentOptions,
+): Promise<AgentResult> {
+  const {
+    config,
+    logger,
+    dryRun = false,
+    mockAgent = false,
+    cwd,
+    prompt,
+  } = options;
 
   if (dryRun) {
-    const kindLabel = config.kind === "process" ? `process: ${config.command} ${config.args.join(" ")}` : `${config.kind} agent`;
+    const kindLabel =
+      config.kind === "process"
+        ? `process: ${config.command} ${config.args.join(" ")}`
+        : `${config.kind} agent`;
     logger.info(`[dry-run] Would run ${kindLabel}`);
     logger.info(`[dry-run] Working directory: ${cwd}`);
     logger.info(`[dry-run] Prompt length: ${prompt.length} characters`);
@@ -143,7 +159,10 @@ export async function runAgentUnion(options: UnionRunAgentOptions): Promise<Agen
   if (mockAgent) {
     logger.info(`[mock-agent] Simulating ${config.kind} agent run...`);
     // Use completion_signal from config if it's a process agent, otherwise default to "DONE"
-    const completionSignal = config.kind === "process" ? config.completion_signal : "<promise>COMPLETE</promise>";
+    const completionSignal =
+      config.kind === "process"
+        ? config.completion_signal
+        : "<promise>COMPLETE</promise>";
     const mockLines = [
       `🤖 [mock-agent] Starting simulated ${config.kind} agent run...`,
       "📋 [mock-agent] Analyzing prompt...",

--- a/src/commands/orchestrator.ts
+++ b/src/commands/orchestrator.ts
@@ -2,10 +2,24 @@ import * as fs from "node:fs/promises";
 import { randomUUID } from "node:crypto";
 import type { Logger } from "../logging";
 import type { Prd, IndexItem, BatchProgress } from "../schemas";
-import { findRepoRoot, findRootFromOptions, getItemDir, getResearchPath, getPlanPath, getPrdPath } from "../fs/paths";
+import {
+  findRepoRoot,
+  findRootFromOptions,
+  getItemDir,
+  getResearchPath,
+  getPlanPath,
+  getPrdPath,
+} from "../fs/paths";
 import { pathExists } from "../fs/util";
 import { loadConfig } from "../config";
-import { readItem, readPrd, writeItem, readBatchProgress, writeBatchProgress, clearBatchProgress } from "../fs/json";
+import {
+  readItem,
+  readPrd,
+  writeItem,
+  readBatchProgress,
+  writeBatchProgress,
+  clearBatchProgress,
+} from "../fs/json";
 import { scanItems } from "./status";
 import { runCommand } from "./run";
 import { writeHealingLog, type HealingLogEntry } from "../agent/healingRunner";
@@ -13,7 +27,11 @@ import type { DoctorConfig } from "../schemas";
 import { TuiViewAdapter } from "../views";
 import type { AgentEvent } from "../tui/agentEvents";
 import { createSimpleProgress } from "../tui";
-import { formatDryRunSummary, formatDryRunRun, type DryRunItemInfo } from "./dryRunFormatter";
+import {
+  formatDryRunSummary,
+  formatDryRunRun,
+  type DryRunItemInfo,
+} from "./dryRunFormatter";
 import { terminateAllAgents } from "../agent/runner";
 
 const STALE_THRESHOLD_MS = 24 * 60 * 60 * 1000; // 24 hours
@@ -24,7 +42,7 @@ const STALE_THRESHOLD_MS = 24 * 60 * 60 * 1000; // 24 hours
 function createBatchProgress(
   queuedItems: string[],
   skippedItems: string[],
-  parallel: number
+  parallel: number,
 ): BatchProgress {
   const now = new Date().toISOString();
   return {
@@ -65,7 +83,7 @@ function isProgressStale(progress: BatchProgress): boolean {
  */
 function areDependenciesSatisfied(
   item: IndexItem,
-  doneItemIds: Set<string>
+  doneItemIds: Set<string>,
 ): boolean {
   if (!item.depends_on || item.depends_on.length === 0) {
     return true;
@@ -108,9 +126,19 @@ function shouldUseTui(noTui?: boolean): boolean {
 
 export async function orchestrateAll(
   options: OrchestratorOptions,
-  logger: Logger
+  logger: Logger,
 ): Promise<OrchestratorResult> {
-  const { force = false, dryRun = false, noTui = false, tuiDebug = false, cwd, mockAgent = false, parallel = 1, noHealing = false, agentKind } = options;
+  const {
+    force = false,
+    dryRun = false,
+    noTui = false,
+    tuiDebug = false,
+    cwd,
+    mockAgent = false,
+    parallel = 1,
+    noHealing = false,
+    agentKind,
+  } = options;
 
   const root = findRootFromOptions(options);
   const config = await loadConfig(root, agentKind ? { agentKind } : undefined);
@@ -144,8 +172,12 @@ export async function orchestrateAll(
           logger.warn("Found stale batch progress, starting fresh");
           await clearBatchProgress(root);
         } else {
-          logger.info(`Resuming batch run (session ${existingProgress.session_id})`);
-          logger.info(`  Progress: ${existingProgress.completed.length} completed, ${existingProgress.failed.length} failed`);
+          logger.info(
+            `Resuming batch run (session ${existingProgress.session_id})`,
+          );
+          logger.info(
+            `  Progress: ${existingProgress.completed.length} completed, ${existingProgress.failed.length} failed`,
+          );
           batchProgress = existingProgress;
 
           // Merge existing progress into result
@@ -159,25 +191,33 @@ export async function orchestrateAll(
 
           // Filter out already-completed items
           const completedSet = new Set(batchProgress.completed);
-          workingNonDoneItems = workingNonDoneItems.filter(item => !completedSet.has(item.id));
+          workingNonDoneItems = workingNonDoneItems.filter(
+            (item) => !completedSet.has(item.id),
+          );
 
           // Handle retry-failed: re-add failed items to queue
           if (retryFailed && batchProgress.failed.length > 0) {
-            logger.info(`  Re-queuing ${batchProgress.failed.length} failed item(s)`);
+            logger.info(
+              `  Re-queuing ${batchProgress.failed.length} failed item(s)`,
+            );
             const failedSet = new Set(batchProgress.failed);
-            const failedItems = items.filter(item => failedSet.has(item.id));
+            const failedItems = items.filter((item) => failedSet.has(item.id));
             workingNonDoneItems.push(...failedItems);
             result.failed = [];
             batchProgress.failed = [];
           } else {
             // Filter out failed items (don't re-process unless --retry-failed)
             const failedSet = new Set(batchProgress.failed);
-            workingNonDoneItems = workingNonDoneItems.filter(item => !failedSet.has(item.id));
+            workingNonDoneItems = workingNonDoneItems.filter(
+              (item) => !failedSet.has(item.id),
+            );
           }
 
           // Clear current_item (will be re-set when processing starts)
           if (batchProgress.current_item) {
-            logger.info(`  Re-queuing interrupted item: ${batchProgress.current_item}`);
+            logger.info(
+              `  Re-queuing interrupted item: ${batchProgress.current_item}`,
+            );
             batchProgress.current_item = null;
           }
         }
@@ -187,9 +227,9 @@ export async function orchestrateAll(
     // Create new session if not resuming
     if (!batchProgress) {
       batchProgress = createBatchProgress(
-        workingNonDoneItems.map(i => i.id),
-        doneItems.map(i => i.id),
-        parallel
+        workingNonDoneItems.map((i) => i.id),
+        doneItems.map((i) => i.id),
+        parallel,
       );
       await writeBatchProgress(root, batchProgress);
       logger.info(`Starting batch run (session ${batchProgress.session_id})`);
@@ -212,8 +252,8 @@ export async function orchestrateAll(
 
       // Check for blocked dependencies in dry-run
       const deps = fullItem.depends_on || [];
-      const blockedBy = deps.filter(id => !allDoneIds.has(id));
-      
+      const blockedBy = deps.filter((id) => !allDoneIds.has(id));
+
       if (blockedBy.length > 0) {
         logger.info(`Item ${item.id} is blocked by: ${blockedBy.join(", ")}`);
       }
@@ -268,13 +308,15 @@ export async function orchestrateAll(
 
     while (remainingItems.length > 0) {
       // Find next runnable item (dependencies satisfied)
-      const runnableItems = remainingItems.filter(item =>
-        areDependenciesSatisfied(item, allDoneIds)
+      const runnableItems = remainingItems.filter((item) =>
+        areDependenciesSatisfied(item, allDoneIds),
       );
 
       if (runnableItems.length === 0) {
         // No runnable items but items remain - likely circular dependency or missing deps
-        logger.warn(`${remainingItems.length} items blocked by unsatisfied dependencies`);
+        logger.warn(
+          `${remainingItems.length} items blocked by unsatisfied dependencies`,
+        );
         result.remaining = remainingItems.map((item) => item.id);
         break;
       }
@@ -291,11 +333,13 @@ export async function orchestrateAll(
       if (useTui && view) {
         view.onActiveItemChanged(item.id);
         view.onPhaseChanged(item.state);
-        view.onItemsChanged(items.map((it) => ({
-          id: it.id,
-          state: it.id === item.id ? "implementing" : it.state,
-          title: it.title,
-        })));
+        view.onItemsChanged(
+          items.map((it) => ({
+            id: it.id,
+            state: it.id === item.id ? "implementing" : it.state,
+            title: it.title,
+          })),
+        );
       } else {
         simpleProgress?.update(item.id, "starting");
       }
@@ -308,17 +352,32 @@ export async function orchestrateAll(
             dryRun: false,
             mockAgent,
             noHealing, // Pass through healing flag (Item 038)
-            onAgentOutput: view ? (chunk) => view.onAgentEvent(item.id, { type: "assistant_text", text: chunk }) : undefined,
-            onAgentEvent: view ? (event: AgentEvent) => view.onAgentEvent(item.id, event) : undefined,
-            onIterationChanged: view ? (iteration, maxIterations) => view.onIterationChanged(iteration, maxIterations) : undefined,
-            onStoryChanged: view ? (story) => view.onStoryChanged(story) : undefined,
-            onPhaseChanged: view ? (phase) => view.onPhaseChanged(phase as any) : undefined,
+            onAgentOutput: view
+              ? (chunk) =>
+                  view.onAgentEvent(item.id, {
+                    type: "assistant_text",
+                    text: chunk,
+                  })
+              : undefined,
+            onAgentEvent: view
+              ? (event: AgentEvent) => view.onAgentEvent(item.id, event)
+              : undefined,
+            onIterationChanged: view
+              ? (iteration, maxIterations) =>
+                  view.onIterationChanged(iteration, maxIterations)
+              : undefined,
+            onStoryChanged: view
+              ? (story) => view.onStoryChanged(story)
+              : undefined,
+            onPhaseChanged: view
+              ? (phase) => view.onPhaseChanged(phase as any)
+              : undefined,
           },
-          logger
+          logger,
         );
         result.completed.push(item.id);
         allDoneIds.add(item.id);
-        remainingItems = remainingItems.filter(i => i.id !== item.id);
+        remainingItems = remainingItems.filter((i) => i.id !== item.id);
 
         // Checkpoint: item completed
         if (batchProgress) {
@@ -329,18 +388,26 @@ export async function orchestrateAll(
         }
 
         if (useTui && view) {
-          view.onItemsChanged(items.map((it) => ({
-            id: it.id,
-            state: it.id === item.id ? "done" : result.completed.includes(it.id) ? "done" : it.state,
-            title: it.title,
-          })));
+          view.onItemsChanged(
+            items.map((it) => ({
+              id: it.id,
+              state:
+                it.id === item.id
+                  ? "done"
+                  : result.completed.includes(it.id)
+                    ? "done"
+                    : it.state,
+              title: it.title,
+            })),
+          );
         } else {
           simpleProgress?.complete(item.id);
         }
       } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
+        const errorMessage =
+          error instanceof Error ? error.message : String(error);
         result.failed.push(item.id);
-        remainingItems = remainingItems.filter(i => i.id !== item.id);
+        remainingItems = remainingItems.filter((i) => i.id !== item.id);
 
         // Checkpoint: item failed
         if (batchProgress) {
@@ -354,13 +421,19 @@ export async function orchestrateAll(
         try {
           const itemDir = getItemDir(root, item.id);
           const currentItem = await readItem(itemDir);
-          await writeItem(itemDir, { ...currentItem, last_error: errorMessage });
+          await writeItem(itemDir, {
+            ...currentItem,
+            last_error: errorMessage,
+          });
         } catch {
           // Best effort
         }
 
         if (useTui && view) {
-          view.onAgentEvent(item.id, { type: "error", message: `Failed ${item.id}: ${errorMessage}` });
+          view.onAgentEvent(item.id, {
+            type: "error",
+            message: `Failed ${item.id}: ${errorMessage}`,
+          });
         } else {
           simpleProgress?.fail(item.id, errorMessage);
         }
@@ -368,12 +441,26 @@ export async function orchestrateAll(
     }
   } else {
     // Parallel processing using worker pool
-    const effectiveParallel = Math.max(1, Math.min(parallel, workingNonDoneItems.length));
-    logger.info(`Processing ${workingNonDoneItems.length} items with ${effectiveParallel} parallel workers`);
+    const effectiveParallel = Math.max(
+      1,
+      Math.min(parallel, workingNonDoneItems.length),
+    );
+    logger.info(
+      `Processing ${workingNonDoneItems.length} items with ${effectiveParallel} parallel workers`,
+    );
     await processItemsParallel(
       workingNonDoneItems,
-      { force, mockAgent, logger, root, simpleProgress, parallel: effectiveParallel, allDoneIds, batchProgress },
-      result
+      {
+        force,
+        mockAgent,
+        logger,
+        root,
+        simpleProgress,
+        parallel: effectiveParallel,
+        allDoneIds,
+        batchProgress,
+      },
+      result,
     );
   }
 
@@ -405,9 +492,18 @@ async function processItemsParallel(
     allDoneIds: Set<string>;
     batchProgress: BatchProgress | null;
   },
-  result: OrchestratorResult
+  result: OrchestratorResult,
 ): Promise<void> {
-  const { force, mockAgent, logger, root, simpleProgress, parallel, allDoneIds, batchProgress } = context;
+  const {
+    force,
+    mockAgent,
+    logger,
+    root,
+    simpleProgress,
+    parallel,
+    allDoneIds,
+    batchProgress,
+  } = context;
 
   // Use a local copy of items still to process
   let queue = [...items];
@@ -431,9 +527,9 @@ async function processItemsParallel(
         if (!item) {
           // No runnable items available right now
           if (queue.length === 0) return;
-          
+
           // Wait a bit and try again
-          await new Promise(resolve => setTimeout(resolve, 1000));
+          await new Promise((resolve) => setTimeout(resolve, 1000));
           continue;
         }
 
@@ -446,7 +542,7 @@ async function processItemsParallel(
           await runCommand(
             item.id,
             { force, dryRun: false, mockAgent, cwd: root },
-            logger
+            logger,
           );
           result.completed.push(item.id);
           allDoneIds.add(item.id);
@@ -460,7 +556,8 @@ async function processItemsParallel(
             await writeBatchProgress(root, batchProgress);
           }
         } catch (error) {
-          const errorMessage = error instanceof Error ? error.message : String(error);
+          const errorMessage =
+            error instanceof Error ? error.message : String(error);
           result.failed.push(item.id);
 
           // Checkpoint: item failed (parallel mode)
@@ -474,14 +571,20 @@ async function processItemsParallel(
           try {
             const itemDir = getItemDir(root, item.id);
             const currentItem = await readItem(itemDir);
-            await writeItem(itemDir, { ...currentItem, last_error: errorMessage });
-          } catch { /* ignore */ }
+            await writeItem(itemDir, {
+              ...currentItem,
+              last_error: errorMessage,
+            });
+          } catch {
+            /* ignore */
+          }
 
           simpleProgress?.fail(item.id, errorMessage);
           logger.error(`✗ Failed ${item.id}: ${errorMessage}`);
         }
       } catch (fatalError) {
-        const msg = fatalError instanceof Error ? fatalError.message : String(fatalError);
+        const msg =
+          fatalError instanceof Error ? fatalError.message : String(fatalError);
         logger.error(`FATAL Worker Error: ${msg}`);
         // If we hit a truly fatal error in the worker logic, we should probably stop this worker
         return;
@@ -500,9 +603,15 @@ async function processItemsParallel(
 
 export async function orchestrateNext(
   options: OrchestratorOptions,
-  logger: Logger
+  logger: Logger,
 ): Promise<{ itemId: string | null; success: boolean }> {
-  const { force = false, dryRun = false, cwd, mockAgent = false, agentKind } = options;
+  const {
+    force = false,
+    dryRun = false,
+    cwd,
+    mockAgent = false,
+    agentKind,
+  } = options;
 
   const root = findRootFromOptions(options);
   const config = await loadConfig(root, agentKind ? { agentKind } : undefined);
@@ -535,15 +644,21 @@ export async function orchestrateNext(
       const itemDir = getItemDir(root, nextItemId);
       const currentItem = await readItem(itemDir);
       await writeItem(itemDir, { ...currentItem, last_error: errorMessage });
-    } catch { /* ignore */ }
+    } catch {
+      /* ignore */
+    }
 
     return { itemId: nextItemId, success: false };
   }
 }
 
-export async function getNextIncompleteItem(root: string): Promise<string | null> {
+export async function getNextIncompleteItem(
+  root: string,
+): Promise<string | null> {
   const items = await scanItems(root);
-  const doneIds = new Set(items.filter(i => i.state === "done").map(i => i.id));
+  const doneIds = new Set(
+    items.filter((i) => i.state === "done").map((i) => i.id),
+  );
 
   // Find first non-done item with satisfied dependencies
   const nextItem = items.find((item) => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,11 +1,15 @@
 import * as fs from "node:fs/promises";
-import { ConfigSchema, PrChecksSchema, BranchCleanupSchema, type Config, type AgentConfigUnion, type SkillConfig } from "./schemas";
+import {
+  ConfigSchema,
+  PrChecksSchema,
+  BranchCleanupSchema,
+  type Config,
+  type AgentConfigUnion,
+  type SkillConfig,
+} from "./schemas";
 import { getConfigPath, getWreckitDir } from "./fs/paths";
 import { safeWriteJson } from "./fs/atomic";
-import {
-  InvalidJsonError,
-  SchemaValidationError,
-} from "./errors";
+import { InvalidJsonError, SchemaValidationError } from "./errors";
 
 export interface PrChecksResolved {
   commands: string[];
@@ -99,7 +103,8 @@ function migrateAgentConfig(agent: any): AgentConfigUnion {
         kind: "process",
         command: agent.command ?? "claude",
         args: agent.args ?? [],
-        completion_signal: agent.completion_signal ?? "<promise>COMPLETE</promise>",
+        completion_signal:
+          agent.completion_signal ?? "<promise>COMPLETE</promise>",
       };
     }
   }
@@ -113,18 +118,30 @@ export function mergeWithDefaults(partial: Partial<Config>): ConfigResolved {
 
   const prChecks = partial.pr_checks
     ? {
-        commands: partial.pr_checks.commands ?? DEFAULT_CONFIG.pr_checks.commands,
-        secret_scan: partial.pr_checks.secret_scan ?? DEFAULT_CONFIG.pr_checks.secret_scan,
-        require_all_stories_done: partial.pr_checks.require_all_stories_done ?? DEFAULT_CONFIG.pr_checks.require_all_stories_done,
-        allow_unsafe_direct_merge: partial.pr_checks.allow_unsafe_direct_merge ?? DEFAULT_CONFIG.pr_checks.allow_unsafe_direct_merge,
-        allowed_remote_patterns: partial.pr_checks.allowed_remote_patterns ?? DEFAULT_CONFIG.pr_checks.allowed_remote_patterns,
+        commands:
+          partial.pr_checks.commands ?? DEFAULT_CONFIG.pr_checks.commands,
+        secret_scan:
+          partial.pr_checks.secret_scan ?? DEFAULT_CONFIG.pr_checks.secret_scan,
+        require_all_stories_done:
+          partial.pr_checks.require_all_stories_done ??
+          DEFAULT_CONFIG.pr_checks.require_all_stories_done,
+        allow_unsafe_direct_merge:
+          partial.pr_checks.allow_unsafe_direct_merge ??
+          DEFAULT_CONFIG.pr_checks.allow_unsafe_direct_merge,
+        allowed_remote_patterns:
+          partial.pr_checks.allowed_remote_patterns ??
+          DEFAULT_CONFIG.pr_checks.allowed_remote_patterns,
       }
     : { ...DEFAULT_CONFIG.pr_checks };
 
   const branchCleanup = partial.branch_cleanup
     ? {
-        enabled: partial.branch_cleanup.enabled ?? DEFAULT_CONFIG.branch_cleanup.enabled,
-        delete_remote: partial.branch_cleanup.delete_remote ?? DEFAULT_CONFIG.branch_cleanup.delete_remote,
+        enabled:
+          partial.branch_cleanup.enabled ??
+          DEFAULT_CONFIG.branch_cleanup.enabled,
+        delete_remote:
+          partial.branch_cleanup.delete_remote ??
+          DEFAULT_CONFIG.branch_cleanup.delete_remote,
       }
     : { ...DEFAULT_CONFIG.branch_cleanup };
 
@@ -144,14 +161,22 @@ export function mergeWithDefaults(partial: Partial<Config>): ConfigResolved {
 
 export function applyOverrides(
   config: ConfigResolved,
-  overrides: ConfigOverrides
+  overrides: ConfigOverrides,
 ): ConfigResolved {
   let agent = config.agent;
 
   // Apply agent kind override if specified
   if (overrides.agentKind && overrides.agentKind !== agent.kind) {
     // Validate the agent kind
-    const validKinds = ["process", "claude_sdk", "amp_sdk", "codex_sdk", "opencode_sdk", "rlm", "sprite"];
+    const validKinds = [
+      "process",
+      "claude_sdk",
+      "amp_sdk",
+      "codex_sdk",
+      "opencode_sdk",
+      "rlm",
+      "sprite",
+    ];
     if (!validKinds.includes(overrides.agentKind)) {
       throw new Error(`Invalid agent kind: ${overrides.agentKind}`);
     }
@@ -166,7 +191,8 @@ export function applyOverrides(
 
   // Apply overrides only for process mode (where command/args/completion_signal are relevant)
   if (agent.kind === "process") {
-    const hasProcessOverrides = overrides.agentCommand !== undefined ||
+    const hasProcessOverrides =
+      overrides.agentCommand !== undefined ||
       overrides.agentArgs !== undefined ||
       overrides.completionSignal !== undefined;
 
@@ -175,7 +201,8 @@ export function applyOverrides(
         ...agent,
         command: overrides.agentCommand ?? (agent as any).command,
         args: overrides.agentArgs ?? (agent as any).args,
-        completion_signal: overrides.completionSignal ?? (agent as any).completion_signal,
+        completion_signal:
+          overrides.completionSignal ?? (agent as any).completion_signal,
       };
     }
   }
@@ -195,7 +222,7 @@ export function applyOverrides(
 
 export async function loadConfig(
   root: string,
-  overrides?: ConfigOverrides
+  overrides?: ConfigOverrides,
 ): Promise<ConfigResolved> {
   const configPath = getConfigPath(root);
   let partial: Partial<Config> = {};
@@ -212,7 +239,7 @@ export async function loadConfig(
     const result = ConfigSchema.safeParse(data);
     if (!result.success) {
       throw new SchemaValidationError(
-        `Schema validation failed for ${configPath}: ${result.error.message}`
+        `Schema validation failed for ${configPath}: ${result.error.message}`,
       );
     }
     partial = result.data;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -55,6 +55,7 @@ export const ErrorCodes = {
   SPRITE_START_FAILED: "SPRITE_START_FAILED",
   SPRITE_ATTACH_FAILED: "SPRITE_ATTACH_FAILED",
   SPRITE_KILL_FAILED: "SPRITE_KILL_FAILED",
+  SPRITE_EXEC_FAILED: "SPRITE_EXEC_FAILED",
 
   // Artifact read errors (for permission/I/O issues)
   ARTIFACT_READ_ERROR: "ARTIFACT_READ_ERROR",
@@ -412,9 +413,7 @@ export function isWreckitError(error: unknown): error is WreckitError {
  * Thrown when the wisp CLI binary is not found.
  */
 export class WispNotFoundError extends WreckitError {
-  constructor(
-    public readonly wispPath: string,
-  ) {
+  constructor(public readonly wispPath: string) {
     super(
       `Wisp CLI not found at '${wispPath}'. Install Wisp to enable Sprite support:\n  https://github.com/example/wisp (replace with actual URL)`,
       ErrorCodes.WISP_NOT_FOUND,
@@ -431,7 +430,10 @@ export class SpriteStartError extends WreckitError {
     public readonly spriteName: string,
     message: string,
   ) {
-    super(`Failed to start Sprite '${spriteName}': ${message}`, ErrorCodes.SPRITE_START_FAILED);
+    super(
+      `Failed to start Sprite '${spriteName}': ${message}`,
+      ErrorCodes.SPRITE_START_FAILED,
+    );
     this.name = "SpriteStartError";
   }
 }
@@ -444,7 +446,10 @@ export class SpriteAttachError extends WreckitError {
     public readonly spriteName: string,
     message: string,
   ) {
-    super(`Failed to attach to Sprite '${spriteName}': ${message}`, ErrorCodes.SPRITE_ATTACH_FAILED);
+    super(
+      `Failed to attach to Sprite '${spriteName}': ${message}`,
+      ErrorCodes.SPRITE_ATTACH_FAILED,
+    );
     this.name = "SpriteAttachError";
   }
 }
@@ -457,7 +462,26 @@ export class SpriteKillError extends WreckitError {
     public readonly spriteName: string,
     message: string,
   ) {
-    super(`Failed to kill Sprite '${spriteName}': ${message}`, ErrorCodes.SPRITE_KILL_FAILED);
+    super(
+      `Failed to kill Sprite '${spriteName}': ${message}`,
+      ErrorCodes.SPRITE_KILL_FAILED,
+    );
     this.name = "SpriteKillError";
+  }
+}
+
+/**
+ * Thrown when command execution inside a Sprite VM fails.
+ */
+export class SpriteExecError extends WreckitError {
+  constructor(
+    public readonly spriteName: string,
+    message: string,
+  ) {
+    super(
+      `Failed to execute command in Sprite '${spriteName}': ${message}`,
+      ErrorCodes.SPRITE_EXEC_FAILED,
+    );
+    this.name = "SpriteExecError";
   }
 }

--- a/src/git/branch.ts
+++ b/src/git/branch.ts
@@ -1,6 +1,11 @@
 import type { Logger } from "../logging";
 import { runGitCommand } from "./index";
-import { BranchError, PushError, MergeConflictError, GitError } from "../errors";
+import {
+  BranchError,
+  PushError,
+  MergeConflictError,
+  GitError,
+} from "../errors";
 
 // Re-export GitOptions from index for type compatibility
 export type { GitOptions } from "./index";
@@ -63,7 +68,12 @@ export async function branchExists(
 export async function cleanupBranch(
   branchName: string,
   baseBranch: string,
-  options: { cwd: string; logger: Logger; dryRun?: boolean; deleteRemote?: boolean },
+  options: {
+    cwd: string;
+    logger: Logger;
+    dryRun?: boolean;
+    deleteRemote?: boolean;
+  },
 ): Promise<BranchCleanupResult> {
   const { logger, dryRun = false, deleteRemote = true } = options;
   const result: BranchCleanupResult = {
@@ -284,9 +294,11 @@ export async function mergeAndPushToBase(
   }
 }
 
-export async function getBranchSyncStatus(
-  options: { cwd: string; logger: Logger; dryRun?: boolean },
-): Promise<"synced" | "ahead" | "behind" | "diverged" | "no-upstream"> {
+export async function getBranchSyncStatus(options: {
+  cwd: string;
+  logger: Logger;
+  dryRun?: boolean;
+}): Promise<"synced" | "ahead" | "behind" | "diverged" | "no-upstream"> {
   const branch = await runGitCommand(
     ["rev-parse", "--abbrev-ref", "HEAD"],
     options,

--- a/src/git/index.ts
+++ b/src/git/index.ts
@@ -168,7 +168,12 @@ export {
 } from "./branch";
 
 // Re-export PR module
-export type { PrResult, PrDetails, PrMergeabilityResult, MergeConflictCheckResult } from "./pr";
+export type {
+  PrResult,
+  PrDetails,
+  PrMergeabilityResult,
+  MergeConflictCheckResult,
+} from "./pr";
 export {
   getPrByBranch,
   createOrUpdatePr,

--- a/src/git/status.ts
+++ b/src/git/status.ts
@@ -81,7 +81,7 @@ export function parseGitStatusPorcelain(
     const statusCodeRaw = line.substring(0, 2);
     // Trim to handle cases like "M " (modified in work tree only)
     const statusCode = statusCodeRaw.trim();
-    
+
     // The path always starts at index 3 (after "XY ")
     // We don't use indexOf(" ") because it might match the leading space
     // in " M file.txt" or spaces inside the filename
@@ -102,9 +102,11 @@ export function parseGitStatusPorcelain(
  * @param options - Git options
  * @returns Array of file changes
  */
-export async function getGitStatus(
-  options: { cwd: string; logger: Logger; dryRun?: boolean },
-): Promise<GitFileChange[]> {
+export async function getGitStatus(options: {
+  cwd: string;
+  logger: Logger;
+  dryRun?: boolean;
+}): Promise<GitFileChange[]> {
   const result = await runGitCommand(["status", "--porcelain"], options);
   return parseGitStatusPorcelain(result.stdout, options.cwd);
 }

--- a/src/git/validation.ts
+++ b/src/git/validation.ts
@@ -222,16 +222,20 @@ export async function isGitRepo(cwd: string): Promise<boolean> {
   });
 }
 
-export async function hasUncommittedChanges(
-  options: { cwd: string; logger: Logger; dryRun?: boolean },
-): Promise<boolean> {
+export async function hasUncommittedChanges(options: {
+  cwd: string;
+  logger: Logger;
+  dryRun?: boolean;
+}): Promise<boolean> {
   const result = await runGitCommand(["status", "--porcelain"], options);
   return result.stdout.length > 0;
 }
 
-export async function isDetachedHead(
-  options: { cwd: string; logger: Logger; dryRun?: boolean },
-): Promise<boolean> {
+export async function isDetachedHead(options: {
+  cwd: string;
+  logger: Logger;
+  dryRun?: boolean;
+}): Promise<boolean> {
   const result = await runGitCommand(
     ["symbolic-ref", "--quiet", "HEAD"],
     options,
@@ -239,9 +243,11 @@ export async function isDetachedHead(
   return result.exitCode !== 0;
 }
 
-export async function hasRemote(
-  options: { cwd: string; logger: Logger; dryRun?: boolean },
-): Promise<boolean> {
+export async function hasRemote(options: {
+  cwd: string;
+  logger: Logger;
+  dryRun?: boolean;
+}): Promise<boolean> {
   const result = await runGitCommand(["remote"], options);
   return result.exitCode === 0 && result.stdout.length > 0;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import {
   spriteListCommand,
   spriteKillCommand,
   spriteAttachCommand,
+  spriteExecCommand,
 } from "./commands/sprite";
 import { learnCommand } from "./commands/learn";
 import { dreamCommand } from "./commands/dream";
@@ -54,7 +55,10 @@ program
   .option("--retry-failed", "Include previously failed items when resuming")
   .option("--no-healing", "Disable automatic self-healing (Item 038)")
   .option("--cwd <path>", "Override the working directory")
-  .option("--agent <kind>", "Agent kind to use (claude_sdk, amp_sdk, codex_sdk, opencode_sdk, rlm)")
+  .option(
+    "--agent <kind>",
+    "Agent kind to use (claude_sdk, amp_sdk, codex_sdk, opencode_sdk, rlm)",
+  )
   .option("--rlm", "Shorthand for --agent rlm");
 
 program.action(async () => {
@@ -444,7 +448,10 @@ program
 const spriteCmd = program
   .command("sprite")
   .description("Manage Sprite VMs (Firecracker microVMs)")
-  .addHelpText("beforeAll", "\nCommands for managing isolated Firecracker microVMs via Wisp.\n");
+  .addHelpText(
+    "beforeAll",
+    "\nCommands for managing isolated Firecracker microVMs via Wisp.\n",
+  );
 
 spriteCmd
   .command("start <name>")
@@ -541,6 +548,34 @@ spriteCmd
         await spriteAttachCommand(
           {
             name,
+            cwd: resolveCwd(globalOpts.cwd),
+            json: options.json,
+          },
+          logger,
+        );
+      },
+      logger,
+      {
+        verbose: globalOpts.verbose,
+        quiet: globalOpts.quiet,
+        dryRun: globalOpts.dryRun,
+        cwd: resolveCwd(globalOpts.cwd),
+      },
+    );
+  });
+
+spriteCmd
+  .command("exec <name> <command...>")
+  .description("Execute a command inside a running Sprite VM")
+  .option("--json", "Output as JSON")
+  .action(async (name, command, options, cmd) => {
+    const globalOpts = cmd.optsWithGlobals();
+    await executeCommand(
+      async () => {
+        await spriteExecCommand(
+          {
+            name,
+            command,
             cwd: resolveCwd(globalOpts.cwd),
             json: options.json,
           },

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -66,17 +66,36 @@ export const RlmSdkAgentSchema = z.object({
   kind: z.literal("rlm"),
   model: z.string().default("claude-sonnet-4-20250514"),
   maxIterations: z.number().default(100),
-  aiProvider: z.enum(["anthropic", "openai", "google", "zai"]).default("anthropic"),
+  aiProvider: z
+    .enum(["anthropic", "openai", "google", "zai"])
+    .default("anthropic"),
 });
 
 export const SpriteAgentSchema = z.object({
   kind: z.literal("sprite"),
-  wispPath: z.string().default("sprite").describe("Path to sprite CLI binary (default: 'sprite' from PATH)"),
-  token: z.string().optional().describe("Sprites.dev authentication token (optional, can use SPRITES_TOKEN env var)"),
+  wispPath: z
+    .string()
+    .default("sprite")
+    .describe("Path to sprite CLI binary (default: 'sprite' from PATH)"),
+  token: z
+    .string()
+    .optional()
+    .describe(
+      "Sprites.dev authentication token (optional, can use SPRITES_TOKEN env var)",
+    ),
   maxVMs: z.number().default(5).describe("Maximum concurrent VMs allowed"),
-  defaultMemory: z.string().default("512MiB").describe("Default memory allocation per VM"),
-  defaultCPUs: z.string().default("1").describe("Default CPU allocation per VM"),
-  timeout: z.number().default(300).describe("Default timeout in seconds for VM operations"),
+  defaultMemory: z
+    .string()
+    .default("512MiB")
+    .describe("Default memory allocation per VM"),
+  defaultCPUs: z
+    .string()
+    .default("1")
+    .describe("Default CPU allocation per VM"),
+  timeout: z
+    .number()
+    .default(300)
+    .describe("Default timeout in seconds for VM operations"),
 });
 
 export const AgentConfigUnionSchema = z.discriminatedUnion("kind", [


### PR DESCRIPTION
### **User description**
## Overview

Add the ability to execute commands inside a running Sprite VM via the `sprite exec` CLI command. This enables Wreckit agents to perform work (clone, build, test) inside the sandbox, not just manage the VM lifecycle.

---

*Automated PR created by wreckit*


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Implement `sprite exec` capability to execute commands inside running Sprite VMs via CLI and RLM tools

- Add `execSprite()` function in `sprite-runner.ts` to execute commands using `sprite exec` subcommand

- Implement `spriteExecCommand()` CLI command with human-readable and JSON output formats

- Register `sprite exec <name> <command...>` subcommand in CLI with `--json` option

- Add `ExecSpriteTool` RLM tool for agent access to sprite exec functionality

- Implement `SpriteExecError` class and `SPRITE_EXEC_FAILED` error code for error handling

- Add support for `SPRITES_` environment variable prefix in agent environment

- Add comprehensive test suite for `spriteExecCommand` with 6 test cases covering success, failure, JSON output, and error scenarios

- Update existing sprite binary references from `wisp` to `sprite`

- Fix environment variable handling in `runWispCommand()` to properly filter undefined values

- Extensive code formatting improvements across multiple files for consistency and readability

- Add documentation including PRD, implementation plan, and research document


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CLI Input<br/>sprite exec"] --> B["spriteExecCommand()"]
  B --> C["execSprite()"]
  C --> D["sprite exec subprocess"]
  D --> E["Command Output"]
  E --> F["JSON/Human Format"]
  
  G["RLM Agent"] --> H["ExecSpriteTool"]
  H --> C
  
  I["Error Handling"] --> J["SpriteExecError"]
  C --> J
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>rlm-tools.ts</strong><dd><code>Add ExecSprite RLM tool and code formatting improvements</code>&nbsp; </dd></summary>
<hr>

src/agent/rlm-tools.ts

<ul><li>Added <code>ExecSpriteTool</code> constant implementing the RLM tool for executing <br>commands inside Sprite VMs<br> <li> Registered <code>ExecSpriteTool</code> in the <code>ALL_TOOLS</code> registry for agent access<br> <li> Reformatted code for consistency: improved line breaks in function <br>signatures, object literals, and JSON.stringify calls<br> <li> Updated <code>buildToolRegistry()</code> function signature formatting</ul>


</details>


  </td>
  <td><a href="https://github.com/jmanhype/wreckit/pull/31/files#diff-5572fa38a2540c8f113201dc2e3a99e3da112e39c5866de3353f0fccf0a9862a">+308/-94</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sprite-runner.ts</strong><dd><code>Implement execSprite function for command execution in VMs</code></dd></summary>
<hr>

src/agent/sprite-runner.ts

<ul><li>Implemented <code>execSprite()</code> function to execute commands inside running <br>Sprite VMs using <code>sprite exec</code> subcommand<br> <li> Added <code>SpriteExecError</code> import from errors module<br> <li> Fixed environment variable handling in <code>runWispCommand()</code> to properly <br>filter undefined values<br> <li> Improved code formatting with consistent line breaks in function <br>signatures and error handling</ul>


</details>


  </td>
  <td><a href="https://github.com/jmanhype/wreckit/pull/31/files#diff-ac45e9ebc7318a5f0086eedb4f2eb6e0f1ecd74220d6f2947d97e7a28dac2dd0">+109/-14</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sprite.ts</strong><dd><code>Add sprite exec CLI command implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/commands/sprite.ts

<ul><li>Added <code>SpriteExecOptions</code> interface with name, command array, cwd, and <br>json properties<br> <li> Implemented <code>spriteExecCommand()</code> function with human-readable and JSON <br>output formats<br> <li> Added error handling for <code>WispNotFoundError</code> and <code>SpriteExecError</code> with <br>appropriate exit codes<br> <li> Improved code formatting consistency across function signatures and <br>error handling blocks</ul>


</details>


  </td>
  <td><a href="https://github.com/jmanhype/wreckit/pull/31/files#diff-25b13d212826139829912709aeb77a0fab79bab187ef3660ed50a6a601a8ef48">+130/-8</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Register sprite exec subcommand in CLI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/index.ts

<ul><li>Imported <code>spriteExecCommand</code> from sprite commands module<br> <li> Registered new <code>sprite exec <name> <command...></code> subcommand with <code>--json</code> option<br> <li> Added command action handler that wires up global options and logger<br> <li> Improved formatting of help text and command descriptions</ul>


</details>


  </td>
  <td><a href="https://github.com/jmanhype/wreckit/pull/31/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80">+37/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>errors.ts</strong><dd><code>Add SpriteExecError class and error code</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/errors.ts

<ul><li>Added <code>SPRITE_EXEC_FAILED</code> error code to <code>ErrorCodes</code> enum<br> <li> Implemented <code>SpriteExecError</code> class extending <code>WreckitError</code> for command <br>execution failures<br> <li> Improved formatting consistency in error class constructors</ul>


</details>


  </td>
  <td><a href="https://github.com/jmanhype/wreckit/pull/31/files#diff-55db69e02ff5714d444d8081ec6ecac5d9833fb29fda64d1e829e5766434fdc0">+30/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>env.ts</strong><dd><code>Add Sprites environment variable support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/agent/env.ts

<ul><li>Added <code>SPRITES_</code> to <code>ALLOWED_PREFIXES</code> array for Sprite environment <br>variable support<br> <li> Improved formatting in function signatures and return type <br>declarations</ul>


</details>


  </td>
  <td><a href="https://github.com/jmanhype/wreckit/pull/31/files#diff-3884c0f8cb1b2992a9c1c91619102c24c167ae149515563f57dcfd0e47a1e921">+9/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Formatting</strong></td><td><details><summary>21 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>orchestrator.ts</strong><dd><code>Code formatting and import organization improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/commands/orchestrator.ts

<ul><li>Reformatted imports and function signatures for improved readability <br>with proper line breaks<br> <li> Adjusted indentation and line wrapping in destructuring assignments <br>and function parameters<br> <li> Improved formatting consistency across async function definitions and <br>callback chains</ul>


</details>


  </td>
  <td><a href="https://github.com/jmanhype/wreckit/pull/31/files#diff-41f0b74eb27a59b696e4bbda77be567d9f27e2346cdbd64564a49efa9205c81c">+176/-61</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>config.ts</strong><dd><code>Code formatting and import organization improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/config.ts

<ul><li>Reformatted imports with improved line breaks for readability<br> <li> Adjusted function parameter formatting and destructuring assignments<br> <li> Improved consistency in conditional expressions and object property <br>assignments</ul>


</details>


  </td>
  <td><a href="https://github.com/jmanhype/wreckit/pull/31/files#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012">+46/-19</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rlm-runner.ts</strong><dd><code>Code formatting and readability improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/agent/rlm-runner.ts

<ul><li>Reformatted function signatures and destructuring assignments for <br>improved readability<br> <li> Improved line breaks in conditional expressions and error handling <br>logic<br> <li> Enhanced formatting consistency in callback definitions and object <br>literals</ul>


</details>


  </td>
  <td><a href="https://github.com/jmanhype/wreckit/pull/31/files#diff-ccc753536d32a6ab56d55e3878f800d159b50c93383a60fc2336d3c7eaec00d4">+54/-39</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>claude-sdk-runner.ts</strong><dd><code>Code formatting and readability improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/agent/claude-sdk-runner.ts

<ul><li>Reformatted function signatures and destructuring assignments for <br>consistency<br> <li> Improved line breaks in conditional expressions and error message <br>concatenation<br> <li> Enhanced formatting in helper functions and type definitions</ul>


</details>


  </td>
  <td><a href="https://github.com/jmanhype/wreckit/pull/31/files#diff-e3ab0a7e4f9291411ab99d9be9aab77f338364f9e4cd1b6fa124fd3d086e2619">+58/-20</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mcporterAdapter.ts</strong><dd><code>Code formatting improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/agent/mcp/mcporterAdapter.ts

<ul><li>Improved code formatting with consistent line breaks in function <br>signatures and conditional logic<br> <li> Enhanced readability in tool filtering and schema conversion</ul>


</details>


  </td>
  <td><a href="https://github.com/jmanhype/wreckit/pull/31/files#diff-a4404e958433652847ebe51720095ef8b1221993abcd26354114047a2702f59f">+11/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>runner.ts</strong><dd><code>Code formatting improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/agent/runner.ts

<ul><li>Reformatted imports and function signatures for improved readability<br> <li> Improved line breaks in conditional expressions and type annotations</ul>


</details>


  </td>
  <td><a href="https://github.com/jmanhype/wreckit/pull/31/files#diff-2b6d6b77763abaf52517f8b743d8815039391f1817f8c7144203f627e370b4d5">+24/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>branch.ts</strong><dd><code>Code formatting improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/git/branch.ts

<ul><li>Reformatted imports and function signatures with improved line breaks<br> <li> Enhanced consistency in parameter object type definitions</ul>


</details>


  </td>
  <td><a href="https://github.com/jmanhype/wreckit/pull/31/files#diff-caa26ac439e9381e582e13b45a9df5543fdeb99ca11f80b4712eced4815befe4">+17/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>schemas.ts</strong><dd><code>Code formatting improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/schemas.ts

<ul><li>Improved formatting of <code>SpriteAgentSchema</code> with better line breaks for <br>readability<br> <li> Enhanced consistency in schema property definitions and descriptions</ul>


</details>


  </td>
  <td><a href="https://github.com/jmanhype/wreckit/pull/31/files#diff-8f5fdeb1cfe9f99fbc1c0a2c351f90ef3531ecdeefa8d0f9a4f0f4127c67f2aa">+25/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dispatcher.ts</strong><dd><code>Code formatting improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/agent/dispatcher.ts

<ul><li>Reformatted imports with improved line breaks for type definitions<br> <li> Enhanced consistency in function signatures</ul>


</details>


  </td>
  <td><a href="https://github.com/jmanhype/wreckit/pull/31/files#diff-fb3fe382d7bcbc759d8d040ed30f82cfaa741825c7f22beaf300f6e8b39c0940">+11/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>validation.ts</strong><dd><code>Code formatting improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/git/validation.ts

<ul><li>Reformatted function signatures with improved line breaks in parameter <br>object types<br> <li> Enhanced consistency in async function definitions</ul>


</details>


  </td>
  <td><a href="https://github.com/jmanhype/wreckit/pull/31/files#diff-c668d6da1420747230d6929316deaad68dd86b6c68a0854ddbe3d143468b882f">+15/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>status.ts</strong><dd><code>Code formatting improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/git/status.ts

<ul><li>Reformatted function signatures with improved line breaks in parameter <br>object types<br> <li> Enhanced consistency in async function definitions</ul>


</details>


  </td>
  <td><a href="https://github.com/jmanhype/wreckit/pull/31/files#diff-091405a51ef0545416e36a613c2a19a0ccdf879ff846357c80c3892037945c13">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rlm-integration.test.ts</strong><dd><code>Code formatting improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/agent/__tests__/rlm-integration.test.ts

- Minor formatting adjustments for consistency


</details>


  </td>
  <td><a href="https://github.com/jmanhype/wreckit/pull/31/files#diff-bdb46c62675035c9b94bd2ac7a9c83edaa5a2ed78028bfd60d2c3721e40aa841">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>process-runner.ts</strong><dd><code>Code formatting improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/agent/process-runner.ts

<ul><li>Reformatted function signatures and debug logging statements for <br>improved readability</ul>


</details>


  </td>
  <td><a href="https://github.com/jmanhype/wreckit/pull/31/files#diff-f37a60ce542f7ab6a4551d7b57b09b6408bf762f47bace7c22213092af86bcb6">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>env-check.test.ts</strong><dd><code>Code formatting improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/__tests__/env-check.test.ts

<ul><li>Removed blank line at file start<br> <li> Improved formatting of conditional statements for readability</ul>


</details>


  </td>
  <td><a href="https://github.com/jmanhype/wreckit/pull/31/files#diff-cfba460bdfedc0898e2a4c3c962c3330294d7ca0df2da4ad96ab340d0734c5c1">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mock-agent.isospec.ts</strong><dd><code>Code formatting improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/__tests__/edge-cases/mock-agent.isospec.ts

- Reformatted imports with improved line breaks for type definitions


</details>


  </td>
  <td><a href="https://github.com/jmanhype/wreckit/pull/31/files#diff-03b77815ad1f1bf1b119eca72d41d82b854cacc46c47ef1a87f640f7a0a29e8b">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Code formatting improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/git/index.ts

- Reformatted type exports with improved line breaks for readability


</details>


  </td>
  <td><a href="https://github.com/jmanhype/wreckit/pull/31/files#diff-a743e737157d3ff72c45160f2e3bd3a890ef6c4f2e56cd5247d82e3fcac210b2">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>errors.isospec.ts</strong><dd><code>Code formatting improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/__tests__/edge-cases/errors.isospec.ts

- Reformatted imports with improved line breaks for type definitions


</details>


  </td>
  <td><a href="https://github.com/jmanhype/wreckit/pull/31/files#diff-909b5f2c90f655b82f2034c4a15b4d29d77dc875026a3579db7bad3521eb83c1">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>agent.test.ts</strong><dd><code>Code formatting improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/__tests__/agent.test.ts

<ul><li>Reformatted array assertion with improved line breaks for readability</ul>


</details>


  </td>
  <td><a href="https://github.com/jmanhype/wreckit/pull/31/files#diff-208162e5396f9f9e0199f0a4cc044437b1648f53eb95ba865a9dccd7897eeb6c">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rlm-runner.test.ts</strong><dd><code>Code formatting improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/agent/__tests__/rlm-runner.test.ts

- Minor formatting adjustments for consistency


</details>


  </td>
  <td><a href="https://github.com/jmanhype/wreckit/pull/31/files#diff-217350fa309eefed6ff5f1c856a6bfa836e1755eb29e55376ff2bbd563ff8df6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>orchestrator.test.ts</strong><dd><code>Code formatting improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/__tests__/commands/orchestrator.test.ts

- Reformatted import statement with improved line breaks


</details>


  </td>
  <td><a href="https://github.com/jmanhype/wreckit/pull/31/files#diff-b1cbe350ffc7459a2f724dd484159f05a0591565288eebffabc4ecd5b1d82576">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>branch-ops.isospec.ts</strong><dd><code>Code formatting improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/__tests__/edge-cases/branch-ops.isospec.ts

- Reformatted import statement with improved line breaks


</details>


  </td>
  <td><a href="https://github.com/jmanhype/wreckit/pull/31/files#diff-470044bb207a667d4d6d01538a732947f9089c9b945dc56bf18abc7df420cd48">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>sprite.test.ts</strong><dd><code>Add spriteExecCommand tests and update sprite binary references</code></dd></summary>
<hr>

src/__tests__/commands/sprite.test.ts

<ul><li>Added comprehensive test suite for <code>spriteExecCommand</code> with 6 test cases <br>covering success, failure, JSON output, and error scenarios<br> <li> Tests verify correct CLI argument passing, exit codes, stdout/stderr <br>handling, and error messages<br> <li> Updated existing test expectations to use <code>sprite</code> instead of <code>wisp</code> <br>binary name<br> <li> Fixed syntax error in existing test (missing closing parenthesis)</ul>


</details>


  </td>
  <td><a href="https://github.com/jmanhype/wreckit/pull/31/files#diff-47a736f15e08b5a83681bd1b4ccd40f97d5728f2c2e76832bc73bd3e560b2b55">+216/-25</a></td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>prd.json</strong><dd><code>Add PRD for sprite exec implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.wreckit/items/075-implement-sprite-exec/prd.json

<ul><li>Created new PRD file documenting the Sprite exec capability <br>implementation<br> <li> Defines 9 user stories covering error handling, core function, CLI <br>integration, RLM tools, and testing<br> <li> All stories marked as complete with detailed acceptance criteria</ul>


</details>


  </td>
  <td><a href="https://github.com/jmanhype/wreckit/pull/31/files#diff-460e0ed178d6454d709ddc492fa298513645d56ef6ce0587c6ea8b2eefc5c9e6">+171/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>plan.md</strong><dd><code>Add implementation plan for sprite exec</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.wreckit/items/075-implement-sprite-exec/plan.md

<ul><li>Created implementation plan documenting current state analysis and <br>missing components<br> <li> Outlines 4 phases: core infrastructure, CLI integration, RLM tool <br>integration, and testing<br> <li> Provides detailed overview of existing Sprite operations and required <br>changes</ul>


</details>


  </td>
  <td><a href="https://github.com/jmanhype/wreckit/pull/31/files#diff-15fc75cc53e7cce40e50affd5997a550382661fc9a5c106372eddc1bd4796e19">+80/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>research.md</strong><dd><code>Research document for Sprite exec command implementation</code>&nbsp; </dd></summary>
<hr>

.wreckit/items/075-implement-sprite-exec/research.md

<ul><li>Comprehensive research document analyzing the implementation of <code>sprite </code><br><code>exec</code> capability for executing commands inside running Sprite VMs<br> <li> Detailed analysis of existing codebase patterns in <code>sprite-runner.ts</code>, <br><code>sprite.ts</code>, <code>rlm-tools.ts</code>, and error handling<br> <li> Provides concrete code examples and patterns to follow for <br>implementing <code>execSprite()</code> function, CLI command, RLM tool, and error <br>classes<br> <li> Identifies risks (command injection, timeout handling, output <br>buffering) with mitigation strategies and open questions about Sprite <br>CLI interface<br> <li> Structured implementation roadmap across 4 phases: core <br>infrastructure, CLI integration, RLM tool integration, and testing</ul>


</details>


  </td>
  <td><a href="https://github.com/jmanhype/wreckit/pull/31/files#diff-57f258357f404025fb47ff34bd5e0c7210e5769a6c4e2358970f3042a53d01e4">+568/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Miscellaneous</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>item.json</strong><dd><code>Mark item 074 as complete</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.wreckit/items/074-sprites-dev-authentication/item.json

<ul><li>Updated item state from <code>critique</code> to <code>done</code><br> <li> Added branch, PR URL, and PR number information<br> <li> Updated timestamps to reflect completion</ul>


</details>


  </td>
  <td><a href="https://github.com/jmanhype/wreckit/pull/31/files#diff-0f9d6532c5cd607b0480456d5a7160ca22a8a68e5b2751439630e845d3e3e546">+9/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>item.json</strong><dd><code>Work item definition for Sprite exec implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.wreckit/items/075-implement-sprite-exec/item.json

<ul><li>Defines work item metadata for implementing <code>sprite exec</code> capability <br>with schema version 1<br> <li> Sets item state to <code>critique</code> and establishes success criteria including <br><code>SpriteRunner.exec()</code> method, CLI command, RLM tool, and integration <br>tests<br> <li> Specifies technical constraints around <code>child_process.spawn</code>, streaming <br>output, and exit code propagation<br> <li> Lists affected source files in scope: <code>sprite-runner.ts</code>, <code>sprite.ts</code>, <br><code>rlm-tools.ts</code>, and test file</ul>


</details>


  </td>
  <td><a href="https://github.com/jmanhype/wreckit/pull/31/files#diff-71ad61636c458c90db89a69f9e0b51c2433206a5a8c64ba52ed454453cc68192">+37/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>opencode-sdk-runner.test.ts</strong></td>
  <td><a href="https://github.com/jmanhype/wreckit/pull/31/files#diff-86e995ba89b846f10ad0101d6fe95882b8275baf38bc75630e09a6a31e5bde39">+15/-10</a>&nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

