### PR TITLE
Implement Remote Tool Proxy for Sprite Agents

### DIFF
--- a/.wreckit/items/075-implement-sprite-exec/item.json
+++ b/.wreckit/items/075-implement-sprite-exec/item.json
@@ -3,14 +3,8 @@
   "id": "075-implement-sprite-exec",
   "title": "Implement Sprite Exec Capability",
   "section": "infrastructure",
-  "state": "critique",
+  "state": "done",
   "overview": "Add the ability to execute commands inside a running Sprite VM via the `sprite exec` CLI command. This enables Wreckit agents to perform work (clone, build, test) inside the sandbox, not just manage the VM lifecycle.",
-  "branch": null,
-  "pr_url": null,
-  "pr_number": null,
-  "last_error": null,
-  "created_at": "2026-01-27T23:55:00.000Z",
-  "updated_at": "2026-01-28T00:11:10.247Z",
   "problem_statement": "The current Sprite integration supports lifecycle (start/stop) but not execution. Agents cannot run commands inside the isolated environment.",
   "motivation": "To fully realize 'Sandbox Mode', agents need to execute shell commands within the Sprite VM.",
   "success_criteria": [
@@ -33,5 +27,11 @@
   ],
   "scope_out_of_scope": [],
   "priority_hint": "high",
-  "urgency_hint": "Missing core capability"
+  "urgency_hint": "Missing core capability",
+  "branch": "wreckit/075-implement-sprite-exec",
+  "pr_url": "https://github.com/jmanhype/wreckit/pull/31",
+  "pr_number": 31,
+  "last_error": null,
+  "created_at": "2026-01-27T23:55:00.000Z",
+  "updated_at": "2026-01-28T01:00:00.000Z"
 }

--- a/.wreckit/items/076-implement-remote-tool-proxy/item.json
+++ b/.wreckit/items/076-implement-remote-tool-proxy/item.json
@@ -1,0 +1,38 @@
+{
+  "schema_version": 1,
+  "id": "076-implement-remote-tool-proxy",
+  "title": "Implement Remote Tool Proxy for Sprite Agents",
+  "section": "infrastructure",
+  "state": "critique",
+  "overview": "Implement a proxy layer that redirects standard agent tools (Bash, Read, Write, Glob, Grep) to execute inside a remote Sprite VM via `sprite exec`. This transforms the `SpriteAgent` into a fully functional, sandboxed runtime environment where agents operate safely in isolation from the host filesystem.",
+  "branch": null,
+  "pr_url": null,
+  "pr_number": null,
+  "last_error": "Not all stories are done",
+  "created_at": "2026-01-28T01:30:00.000Z",
+  "updated_at": "2026-01-28T02:05:48.933Z",
+  "problem_statement": "Currently, setting `agent.kind: \"sprite\"` only verifies connectivity. It does not actually run the agent's work inside the VM. To achieve true sandboxing, the agent's tools must be intercepted and executed remotely.",
+  "motivation": "To enable safe, ephemeral agent execution where 'rm -rf /' destroys a disposable microVM, not the user's laptop.",
+  "success_criteria": [
+    "`runSpriteAgent` initializes a Sprite VM (or connects to an existing one)",
+    "Standard tools (Bash, Read, Write, Glob, Grep) are proxied to `sprite exec` calls",
+    "File content reading/writing handles binary data and escaping correctly (likely via base64)",
+    "The agent can successfully run a basic task (e.g., 'create a file and check its content') inside the VM"
+  ],
+  "technical_constraints": [
+    "Must use existing `execSprite` primitive",
+    "Must be compatible with existing RLM tool interfaces",
+    "Must handle latency and timeouts gracefully"
+  ],
+  "scope_in_scope": [
+    "src/agent/sprite-runner.ts",
+    "src/agent/remote-tools.ts",
+    "src/agent/dispatcher.ts"
+  ],
+  "scope_out_of_scope": [
+    "Full file synchronization (rsyncing host project to VM) - this is a future task",
+    "Interactive TTY proxying"
+  ],
+  "priority_hint": "high",
+  "urgency_hint": "Required to make sandbox mode useful"
+}

--- a/.wreckit/items/076-implement-remote-tool-proxy/plan.md
+++ b/.wreckit/items/076-implement-remote-tool-proxy/plan.md
@@ -1,0 +1,36 @@
+# Implement Remote Tool Proxy for Sprite Agents
+
+## Overview
+Implement a proxy layer that redirects standard agent tools (Bash, Read, Write, Glob, Grep) to execute inside a remote Sprite VM via `sprite exec`. This transforms the `SpriteAgent` into a fully functional, sandboxed runtime environment.
+
+## Current State Analysis
+- **Runner:** `runSpriteAgent` currently only checks connectivity.
+- **Tools:** `execSprite` primitive exists but is not used by agent tools.
+- **Schema:** `SpriteAgentConfig` lacks `vmName` for persistent sessions.
+
+## Phases
+
+### Phase 1: Remote Tool Implementations
+**Goal:** Create `src/agent/remote-tools.ts` with proxied versions of standard tools.
+- Implement `RemoteReadTool`: `cat <file> | base64`
+- Implement `RemoteWriteTool`: `echo <base64> | base64 -d > <file>`
+- Implement `RemoteBashTool`: `execSprite(..., ["bash", "-c", command])`
+- Implement `RemoteGlobTool`: `find` command wrapper.
+- Implement `RemoteGrepTool`: `grep` command wrapper.
+- Export `buildRemoteToolRegistry`.
+
+### Phase 2: Schema Updates
+**Goal:** Add `vmName` to configuration.
+- Update `SpriteAgentSchema` in `src/schemas.ts`.
+
+### Phase 3: Runner Integration
+**Goal:** Update `runSpriteAgent` to initialize the AI agent with remote tools.
+- Auto-generate or use `vmName`.
+- Call `ensureSpriteRunning` (start if not running).
+- Initialize `AxAgent` with `remoteTools`.
+- Execute agent loop.
+
+### Phase 4: Testing
+**Goal:** Verify tool proxying works.
+- Add unit tests for `remote-tools.ts` mocking `execSprite`.
+- Verify base64 encoding/decoding logic.

--- a/.wreckit/items/076-implement-remote-tool-proxy/prd.json
+++ b/.wreckit/items/076-implement-remote-tool-proxy/prd.json
@@ -1,0 +1,57 @@
+{
+  "schema_version": 1,
+  "id": "076-implement-remote-tool-proxy",
+  "branch_name": "wreckit/076-implement-remote-tool-proxy",
+  "user_stories": [
+    {
+      "id": "US-076-001",
+      "title": "Implement Remote Tools Module",
+      "acceptance_criteria": [
+        "Create `src/agent/remote-tools.ts`",
+        "Implement `RemoteReadTool` using `execSprite` and base64",
+        "Implement `RemoteWriteTool` using `execSprite` and base64",
+        "Implement `RemoteBashTool`",
+        "Implement `RemoteGlobTool` and `RemoteGrepTool`",
+        "Export `buildRemoteToolRegistry`"
+      ],
+      "priority": 1,
+      "status": "done",
+      "notes": "Ensure robust base64 handling for binary safety."
+    },
+    {
+      "id": "US-076-002",
+      "title": "Update Sprite Config Schema",
+      "acceptance_criteria": [
+        "Add `vmName` optional field to `SpriteAgentSchema` in `src/schemas.ts`"
+      ],
+      "priority": 2,
+      "status": "done",
+      "notes": "Allows users to specify a persistent VM name."
+    },
+    {
+      "id": "US-076-003",
+      "title": "Update runSpriteAgent Runner",
+      "acceptance_criteria": [
+        "Rewrite `runSpriteAgent` in `src/agent/sprite-runner.ts`",
+        "Initialize `AxAgent` with remote tools",
+        "Implement `ensureSpriteRunning` logic",
+        "Handle agent execution loop and output"
+      ],
+      "priority": 2,
+      "status": "done",
+      "notes": "Replace the connectivity check with actual agent execution."
+    },
+    {
+      "id": "US-076-004",
+      "title": "Add Unit Tests for Remote Tools",
+      "acceptance_criteria": [
+        "Create `src/__tests__/agent/remote-tools.test.ts`",
+        "Test each remote tool with mocked `execSprite`",
+        "Verify command construction and output parsing"
+      ],
+      "priority": 3,
+      "status": "done",
+      "notes": "Verify proxy logic without needing a real VM."
+    }
+  ]
+}

--- a/.wreckit/items/076-implement-remote-tool-proxy/research.md
+++ b/.wreckit/items/076-implement-remote-tool-proxy/research.md
@@ -1,0 +1,544 @@
+# Research: Implement Remote Tool Proxy for Sprite Agents
+
+**Date**: 2025-01-28
+**Item**: 076-implement-remote-tool-proxy
+
+## Research Question
+Implement a proxy layer that redirects standard agent tools (Bash, Read, Write, Glob, Grep) to execute inside a remote Sprite VM via `sprite exec`. This transforms the `SpriteAgent` into a fully functional, sandboxed runtime environment where agents operate safely in isolation from the host filesystem.
+
+## Summary
+
+The current `SpriteAgent` implementation (`src/agent/sprite-runner.ts:516-634`) only verifies connectivity to the Sprite CLI and does not actually execute agent work inside the VM. To achieve true sandboxing where agents can safely run dangerous commands like `rm -rf /` without affecting the host, we need to intercept standard agent tool calls and proxy them through `sprite exec` to run inside a disposable microVM.
+
+This research reveals that the codebase has excellent infrastructure to build upon. The `execSprite()` primitive at `src/agent/sprite-runner.ts:446-486` already provides the core capability to execute commands inside a Sprite VM with proper timeout handling, streaming output, and error management. The RLM agent runner (`src/agent/rlm-runner.ts:64-200`) demonstrates how to initialize an AI agent with custom tools, and the tool registry system (`src/agent/rlm-tools.ts:663-698`) shows how to swap out tool implementations. The tool allowlist system (`src/agent/toolAllowlist.ts:58-143`) provides security boundaries that can be extended to support sandbox-aware tool restrictions.
+
+The implementation requires creating remote proxy versions of the standard tools (RemoteRead, RemoteWrite, RemoteGlob, RemoteGrep, RemoteBash) that wrap `execSprite()` calls, integrating these into the `runSpriteAgent()` function following the RLM runner pattern, and ensuring proper binary data handling via base64 encoding for file operations.
+
+## Current State Analysis
+
+### Existing Implementation
+
+**Sprite Runner Infrastructure**: `src/agent/sprite-runner.ts:1-635` provides the foundation:
+
+- **Core Primitive**: `execSprite()` at lines 446-486 executes commands inside a Sprite VM
+  - Uses `runWispCommand()` with `["exec", name, ...command]` args (line 456)
+  - Supports streaming output via optional callbacks (lines 451-454)
+  - Handles timeouts and SIGTERM→SIGKILL escalation (via `runWispCommand` at lines 154-173)
+  - Returns `WispResult` with exit code, stdout, stderr (lines 30-36)
+  - Distinguishes between subprocess errors (throw) and command failures (return success=false)
+
+- **Agent Runner**: `runSpriteAgent()` at lines 516-634
+  - Currently only verifies connectivity via `listSprites()` (line 570)
+  - Does not initialize AI agent or run tools
+  - Placeholder output noting full execution not implemented (lines 596-598)
+  - **Missing**: No tool proxying, no agent initialization inside VM
+
+- **VM Lifecycle Functions**: Lines 269-419 provide Sprite management
+  - `startSprite()` (lines 269-307): Creates new VM
+  - `attachSprite()` (lines 317-347): Attaches to console
+  - `listSprites()` (lines 356-379): Lists active VMs
+  - `killSprite()` (lines 389-419): Terminates VM
+
+**RLM Agent Reference Pattern**: `src/agent/rlm-runner.ts:64-200` shows the full agent initialization pattern:
+
+```typescript
+// 1. Build Environment (lines 88-92)
+const env = await buildAxAIEnv({ cwd, logger, provider: config.aiProvider });
+
+// 2. Initialize AI Service (lines 95-126)
+let ai: AxAIService;
+if (config.aiProvider === "anthropic") {
+  ai = new AxAIAnthropic({ apiKey: env.ANTHROPIC_API_KEY, ... });
+}
+
+// 3. Initialize JS Runtime (lines 128-133)
+const jsRuntime = new JSRuntime({ CONTEXT_DATA: prompt, cwd });
+
+// 4. Initialize Tools (lines 136-147)
+const builtInTools = buildToolRegistry(options.allowedTools, jsRuntime);
+const mcpTools = adaptMcpServersToAxTools(options.mcpServers, options.allowedTools);
+const tools = [...builtInTools, ...mcpTools];
+
+// 5. Create Agent (lines 153-172)
+const agent = new AxAgent(ai, { tools });
+```
+
+**Standard Tool Implementations**: `src/agent/rlm-tools.ts:67-251` shows the tools to proxy:
+
+- `ReadTool` (lines 67-85): Uses `fs.readFile()` - needs to become `cat` via execSprite
+- `WriteTool` (lines 87-114): Uses `fs.writeFile()` - needs to become `tee` or base64 wrapper
+- `GlobTool` (lines 152-186): Uses `find` command - already command-based, easy to proxy
+- `GrepTool` (lines 188-231): Uses `grep -r` - already command-based, easy to proxy
+- `BashTool` (lines 233-251): Uses `exec()` - needs to be wrapped in execSprite
+
+**Tool Registry System**: `src/agent/rlm-tools.ts:663-698` manages tool availability:
+
+```typescript
+const ALL_TOOLS: ToolRegistry = {
+  Read: ReadTool,
+  Write: WriteTool,
+  Edit: EditTool,
+  Glob: GlobTool,
+  Grep: GrepTool,
+  Bash: BashTool,
+  // Sprite tools...
+  SpawnSprite: SpawnSpriteTool,
+  ExecSprite: ExecSpriteTool,
+  // ...
+};
+
+export function buildToolRegistry(allowedTools?: string[], jsRuntime?: JSRuntime): AxFunction[] {
+  let tools = allowedTools
+    ? allowedTools.map((name) => ALL_TOOLS[name]).filter(Boolean)
+    : Object.values(ALL_TOOLS);
+  if (jsRuntime) {
+    tools.push(createRunJSTool(jsRuntime));
+  }
+  return tools;
+}
+```
+
+**Tool Allowlist System**: `src/agent/toolAllowlist.ts:19-143` provides phase-based security:
+
+- `AVAILABLE_TOOLS` (lines 19-38): Lists all available tool names
+- `PHASE_TOOL_ALLOWLISTS` (lines 58-143): Maps phases to allowed tools
+- `getAllowedToolsForPhase()` (lines 151-153): Retrieves allowlist for a phase
+- **Gap**: No distinction between local and sandboxed tool variants
+
+**Configuration Schema**: `src/schemas.ts:74-99` defines `SpriteAgentConfig`:
+
+```typescript
+export const SpriteAgentSchema = z.object({
+  kind: z.literal("sprite"),
+  wispPath: z.string().default("sprite"),
+  token: z.string().optional(), // Sprites.dev auth token
+  maxVMs: z.number().default(5),
+  defaultMemory: z.string().default("512MiB"),
+  defaultCPUs: z.string().default("1"),
+  timeout: z.number().default(300),
+});
+```
+
+- **Missing**: No field to specify VM name for agent session
+- **Missing**: No field to enable/disable tool proxying mode
+
+**Error Handling**: `src/errors.ts:476-487` already has `SpriteExecError`:
+
+```typescript
+export class SpriteExecError extends WreckitError {
+  constructor(
+    public readonly spriteName: string,
+    message: string,
+  ) {
+    super(
+      `Failed to execute command in Sprite '${spriteName}': ${message}`,
+      ErrorCodes.SPRITE_EXEC_FAILED,
+    );
+    this.name = "SpriteExecError";
+  }
+}
+```
+
+- **Already available**: Error code `SPRITE_EXEC_FAILED` exists (line 58)
+
+### Key Files
+
+| File | Purpose | Lines of Interest | Changes Required |
+|------|---------|-------------------|------------------|
+| `src/agent/sprite-runner.ts` | Sprite VM management | 446-486 (`execSprite`), 516-634 (`runSpriteAgent`) | Create remote tool implementations, rewrite `runSpriteAgent()` to initialize AI with remote tools |
+| `src/agent/rlm-tools.ts` | Standard tool implementations | 67-251 (Read/Write/Glob/Grep/Bash), 663-698 (tool registry) | Add remote tool variants, extend registry with remote tools |
+| `src/agent/rlm-runner.ts` | RLM agent reference pattern | 64-200 (agent initialization) | Follow pattern for Sprite agent initialization |
+| `src/agent/toolAllowlist.ts` | Phase-based tool restrictions | 19-38 (AVAILABLE_TOOLS), 58-143 (PHASE_TOOL_ALLOWLISTS) | Add remote tool variants to allowlists |
+| `src/schemas.ts` | Configuration schemas | 74-99 (`SpriteAgentSchema`) | Add `vmName` field, potentially `enableProxy` flag |
+| `src/agent/dispatcher.ts` | Agent dispatch router | 177-190 (sprite case) | Ensure proper option passing to sprite runner |
+
+## Technical Considerations
+
+### Dependencies
+
+**External Dependencies**:
+- `sprite` CLI from Sprites.dev (already required by Items 073-075)
+- No additional npm packages needed
+
+**Internal Modules** to integrate with:
+- `src/agent/sprite-runner.ts:446-486` - Use `execSprite()` for all remote tool calls
+- `src/agent/rlm-tools.ts:663-698` - Extend tool registry with remote variants
+- `src/agent/rlm-runner.ts:64-200` - Follow agent initialization pattern
+- `src/agent/toolAllowlist.ts:19-143` - Add remote tool names to allowlists
+- `src/schemas.ts:74-99` - Extend schema for VM name and proxy configuration
+- `src/errors.ts:476-487` - Use existing `SpriteExecError` for proxy failures
+
+### Patterns to Follow
+
+**1. Remote Tool Implementation Pattern**:
+
+Create remote wrapper tools that follow this pattern:
+
+```typescript
+const RemoteReadTool: AxFunction = {
+  name: "Read", // Same name as local tool for transparency
+  description: "Read file contents from inside the Sprite VM sandbox",
+  parameters: {
+    type: "object",
+    properties: {
+      path: { type: "string", description: "File path inside the VM" },
+    },
+    required: ["path"],
+  } as AxFunctionJSONSchema,
+  func: async ({ path: filePath }: { path: string }) => {
+    try {
+      const { execSprite } = await import("./sprite-runner.js");
+
+      // Use base64 encoding to handle binary data and special characters
+      const result = await execSprite(
+        vmName, // Passed via closure or config
+        ["sh", "-c", `cat "${filePath}" | base64`],
+        config,
+        logger
+      );
+
+      if (result.success) {
+        const base64Content = result.stdout.trim();
+        const content = Buffer.from(base64Content, 'base64').toString('utf-8');
+        return content;
+      } else {
+        return `Error reading file ${filePath}: ${result.stderr}`;
+      }
+    } catch (error: any) {
+      return `Error reading file ${filePath}: ${error.message}`;
+    }
+  },
+};
+```
+
+**2. Agent Initialization Pattern** (from `src/agent/rlm-runner.ts`):
+
+```typescript
+export async function runSpriteAgent(
+  config: SpriteAgentConfig,
+  options: SpriteRunAgentOptions,
+): Promise<AgentResult> {
+  const { cwd, prompt, logger, allowedTools, mcpServers } = options;
+
+  // 1. Initialize or connect to Sprite VM
+  const vmName = config.vmName || `agent-session-${Date.now()}`;
+  const vmReady = await ensureSpriteRunning(vmName, config, logger);
+  if (!vmReady) {
+    return { success: false, output: "Failed to initialize Sprite VM", ... };
+  }
+
+  // 2. Build AI service (reuse RLM pattern or use Claude SDK)
+  const ai = await buildAIService(config, logger);
+
+  // 3. Build remote tool registry
+  const remoteTools = buildRemoteToolRegistry(
+    allowedTools,
+    vmName,
+    config,
+    logger
+  );
+
+  // 4. Add MCP servers if provided
+  const mcpTools = mcpServers
+    ? adaptMcpServersToAxTools(mcpServers, allowedTools)
+    : [];
+
+  const tools = [...remoteTools, ...mcpTools];
+
+  // 5. Create and run agent
+  const agent = new AxAgent(ai, { tools });
+  let output = "";
+  for await (const message of agent.query({ prompt })) {
+    output += formatMessage(message);
+    if (options.onStdoutChunk) {
+      options.onStdoutChunk(formatMessage(message));
+    }
+  }
+
+  return { success: true, output, ... };
+}
+```
+
+**3. Binary Data Handling Pattern**:
+
+Use base64 encoding for file content to handle:
+- Binary files (images, executables)
+- Files with special characters (newlines, quotes, control chars)
+- Large files that might break shell command parsing
+
+```typescript
+// Write file with base64 encoding
+const result = await execSprite(vmName,
+  ["sh", "-c", `echo "${base64Content}" | base64 -d | tee "${filePath}"`],
+  config, logger
+);
+
+// Read file with base64 encoding
+const result = await execSprite(vmName,
+  ["sh", "-c", `cat "${filePath}" | base64`],
+  config, logger
+);
+```
+
+**4. VM Lifecycle Management Pattern**:
+
+```typescript
+async function ensureSpriteRunning(
+  name: string,
+  config: SpriteAgentConfig,
+  logger: Logger
+): Promise<boolean> {
+  // Check if VM already exists
+  const listResult = await listSprites(config, logger);
+  const sprites = parseWispJson(listResult.stdout, logger) as WispSpriteInfo[];
+  const exists = sprites?.some(s => s.name === name && s.state === "running");
+
+  if (exists) {
+    logger.debug(`Sprite VM '${name}' already running`);
+    return true;
+  }
+
+  // Start new VM
+  logger.info(`Starting Sprite VM '${name}'...`);
+  const startResult = await startSprite(name, config, logger);
+  return startResult.success;
+}
+```
+
+**5. Error Handling Pattern**:
+
+```typescript
+try {
+  const result = await execSprite(vmName, command, config, logger);
+  if (!result.success && result.exitCode !== 0) {
+    // Command failed inside VM - return error to agent, don't throw
+    return `Command failed with exit code ${result.exitCode}: ${result.stderr}`;
+  }
+  // Process successful result...
+} catch (error) {
+  if (error instanceof SpriteExecError) {
+    // Subprocess error (exec failure) - return error to agent
+    return `Failed to execute command in VM: ${error.message}`;
+  }
+  // Other errors - log and return
+  logger.error(`Unexpected error in remote tool: ${error}`);
+  return `Unexpected error: ${error}`;
+}
+```
+
+## Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| **File content corruption** | High - File data loss/binary corruption | Use base64 encoding for all file read/write operations; test with binary files (PNG, PDF); validate encoding round-trip |
+| **Command injection vulnerabilities** | High - Security breach | Never use shell interpolation; pass commands as array to `execSprite()`; escape file paths properly; use `-c` wrapper scripts carefully |
+| **VM not initialized** | Medium - Tool failures | Check VM state in `runSpriteAgent()` before starting; auto-start VM if missing; fail fast with clear error if VM startup fails |
+| **Latency impacting agent performance** | Medium - Slow execution | Cache frequently read files; batch operations when possible; document latency expectations; consider async non-blocking tool design |
+| **Timeouts on long operations** | Medium - Incomplete work | Respect `config.timeout` (default 300s); allow streaming output for long-running commands; implement proper SIGTERM→SIGKILL escalation |
+| **Path mapping issues** | Medium - File not found errors | Clearly document that paths are relative to VM filesystem, not host; add path validation helper; test with nested paths and symlinks |
+| **Concurrent tool calls to same VM** | Low - Race conditions | Sprite CLI likely serializes exec calls; document limitation; consider queueing if issues arise |
+| **Large file transfers** | Low - Memory/performance issues | Stream output via callbacks; document size limitations; use chunked base64 for very large files (>10MB) |
+| **VM state drift** | Low - Inconsistent behavior | Document that VM is mutable; agents should not rely on state persistence; consider ephemeral VM per session |
+| **Error message obscuration** | Low - Debugging difficulty | Preserve both stdout and stderr in tool responses; include exit code in error messages; add debug mode with verbose output |
+
+## Recommended Approach
+
+### Phase 1: Remote Tool Implementations
+
+1. **Create `src/agent/remote-tools.ts`**:
+   - Implement `RemoteReadTool` using `cat` + base64 encoding
+   - Implement `RemoteWriteTool` using `tee` + base64 decoding
+   - Implement `RemoteGlobTool` using `find` command (already shell-based)
+   - Implement `RemoteGrepTool` using `grep -r` command (already shell-based)
+   - Implement `RemoteBashTool` as wrapper around `execSprite()`
+   - Export `buildRemoteToolRegistry(vmName, config, logger, allowedTools?)` function
+
+2. **Add VM Name to Schema** in `src/schemas.ts:74-99`:
+   ```typescript
+   export const SpriteAgentSchema = z.object({
+     kind: z.literal("sprite"),
+     wispPath: z.string().default("sprite"),
+     token: z.string().optional(),
+     vmName: z.string().optional().describe(
+       "Name of Sprite VM to run agent in (auto-generated if not specified)"
+     ),
+     // ... existing fields
+   });
+   ```
+
+3. **Add Remote Tools to Allowlists** in `src/agent/toolAllowlist.ts:19-38`:
+   - Add to `AVAILABLE_TOOLS`:
+     ```typescript
+     RemoteRead: "Read", // Same name, proxied implementation
+     RemoteWrite: "Write",
+     RemoteBash: "Bash",
+     RemoteGlob: "Glob",
+     RemoteGrep: "Grep",
+     ```
+   - No changes needed to `PHASE_TOOL_ALLOWLISTS` (tools keep same names)
+
+### Phase 2: Agent Runner Integration
+
+4. **Rewrite `runSpriteAgent()`** in `src/agent/sprite-runner.ts:516-634`:
+   - Remove placeholder connectivity check
+   - Add `ensureSpriteRunning()` helper to initialize/connect to VM
+   - Import `buildRemoteToolRegistry()` from remote-tools.ts
+   - Import `buildAxAIEnv()` and AI service classes from RLM runner
+   - Follow RLM runner pattern: build env → initialize AI → build tools → create agent
+   - Handle timeout, abort controller, and event callbacks
+   - Return proper `AgentResult` with output, exit code, completion status
+
+5. **Add AI Service Builder** in `src/agent/sprite-runner.ts` or `src/agent/env.ts`:
+   - Create `buildSpriteAI()` function that:
+     - Detects AI provider from environment or config
+     - Initializes `AxAIAnthropic`, `AxAIOpenAI`, or `AxAIGoogleGemini`
+     - Handles authentication via environment variables
+     - Returns configured `AxAIService` instance
+
+6. **Update Dispatcher** in `src/agent/dispatcher.ts:177-190`:
+   - Verify that all options are passed correctly to `runSpriteAgent()`
+   - Ensure `allowedTools`, `mcpServers`, `timeoutSeconds` are forwarded
+   - No changes needed if options already match
+
+### Phase 3: Testing & Validation
+
+7. **Add Unit Tests** in `src/__tests__/agent/sprite-runner.test.ts`:
+   - Test `ensureSpriteRunning()` with existing and non-existing VMs
+   - Test each remote tool with mocked `execSprite()` calls
+   - Test base64 encoding/decoding for file content
+   - Test error handling (VM not found, command failure, timeout)
+   - Test agent initialization with different AI providers
+
+8. **Integration Tests** (if Sprite CLI available):
+   - Test full agent execution: start VM → run agent → verify file operations
+   - Test with binary files (PNG, PDF) to validate base64 encoding
+   - Test with large files to verify performance
+   - Test concurrent tool calls to same VM
+   - Test latency and timeout handling
+
+9. **Add Test Scenarios**:
+   - Basic: Agent creates a file and reads it back
+   - Complex: Agent clones a repo, runs tests, creates a new file
+   - Error handling: Agent tries to delete system files (should fail safely)
+   - Binary: Agent reads and writes an image file
+   - Long-running: Agent runs `npm install` (test timeout/streaming)
+
+### Phase 4: Documentation & Polish
+
+10. **Update Documentation**:
+    - Add SPRITES_AGENT_USAGE.md with:
+      - How to configure Sprite agent in `.wreckit/config.json`
+      - Explanation of sandboxing guarantees
+      - Performance expectations (latency, timeouts)
+      - Troubleshooting guide
+    - Update README.md Cloud Sandboxes section
+    - Add examples to MIGRATION.md
+
+11. **Error Messages**:
+    - Ensure all remote tool errors include context (VM name, file path, exit code)
+    - Add helpful hints for common issues (VM not running, permission denied)
+    - Document error codes in user-facing docs
+
+12. **Performance Optimization** (if needed):
+    - Implement file read caching for frequently accessed files
+    - Add batch operations (read multiple files in one exec call)
+    - Consider async tool design for long-running operations
+
+## Open Questions
+
+1. **AI Provider Configuration**: Should Sprite agents support multiple AI providers (anthropic, openai, google) like RLM agents?
+   - **Recommendation**: Yes, reuse `buildAxAIEnv()` and provider detection from RLM runner for consistency
+
+2. **VM Lifecycle Strategy**: Should the agent start a new VM each run or reuse existing VMs?
+   - **Auto-start (recommended)**: Start VM if not running, reuse if exists
+   - **Ephemeral**: Always create new VM, delete on completion
+   - **Persistent**: Require user to pre-start VM via CLI
+   - **Recommendation**: Auto-start for ease of use; add config option `ephemeral: boolean` for future
+
+3. **VM Name Generation**: How to generate VM names if not specified in config?
+   - Timestamp-based: `agent-session-${Date.now()}`
+   - UUID-based: `agent-${uuid()}`
+   - User-specific: `agent-${USER}-${Date.now()}`
+   - **Recommendation**: Use `agent-session-${Date.now()}` with optional prefix from config
+
+4. **File Path Semantics**: How should relative paths be handled?
+   - Relative to VM's current directory (usually `/home/user`)
+   - Relative to a project directory mounted into VM?
+   - Absolute paths only?
+   - **Recommendation**: Support both absolute and relative paths; relative paths resolve to VM's home directory (document this clearly)
+
+5. **Working Directory**: What working directory should the agent operate in?
+   - VM's home directory (`/home/sprite` or `/root`)
+   - A mounted project directory from host?
+   - Configurable via `agent.cwd` field?
+   - **Recommendation**: Start with VM's home; add `cwd` field to schema later for project mounting
+
+6. **Binary File Size Limits**: What's the maximum file size for base64 encoding?
+   - Base64 increases size by 33%
+   - Large files (>10MB) may cause memory issues
+   - **Recommendation**: Document 10MB soft limit; add chunking for larger files in future enhancement
+
+7. **Concurrent Tool Execution**: Should multiple tools be able to execute simultaneously in the same VM?
+   - Sprite CLI likely serializes exec calls
+   - Risk of race conditions if tools mutate shared state
+   - **Recommendation**: Serialize tool calls for safety; document as known limitation
+
+8. **VM State Persistence**: Should the VM persist between agent runs?
+   - Persistent: Faster for subsequent runs, but state drift
+   - Ephemeral: Clean state every time, but slower startup
+   - **Recommendation**: Default to persistent (VM stays running); add `ephemeral` config option to auto-delete on completion
+
+9. **MCP Server Support**: Should Sprite agents support MCP servers?
+   - RLM runner already supports MCP (`adaptMcpServersToAxTools`)
+   - MCP tools would run on host, not inside VM (security risk?)
+   - **Recommendation**: Support MCP but document security implications; add `mcpSandboxed` config flag for future
+
+10. **Fallback to Local Tools**: What happens if VM exec fails?
+    - Fail all tool calls?
+    - Fall back to local tools (security risk)?
+    - Retry VM connection?
+    - **Recommendation**: Fail all tool calls with clear error; do NOT silently fall back to local tools (would break sandboxing guarantees)
+
+11. **Resource Limits**: How to prevent agent from consuming all VM resources?
+    - Sprite VMs have memory/CPU limits via `--memory` and `--cpus` flags
+    - Should we add disk limits? Network limits?
+    - **Recommendation**: Rely on Sprite's existing resource limits; document that agents can fill disk
+
+12. **Interactive Commands**: How to handle commands requiring user input (e.g., `npm login`)?
+    - Block interactive commands explicitly?
+    - Allow stdin passthrough via `sprite exec`?
+    - **Recommendation**: Explicitly document as non-interactive only; commands that read stdin will timeout or fail
+
+## Implementation Notes
+
+- **Reuse `execSprite()` Primitive**: The core primitive at `src/agent/sprite-runner.ts:446-486` already handles subprocess spawning, timeout enforcement, output capture, and error detection. Simply pass different commands for each tool.
+
+- **Follow RLM Runner Pattern**: The agent initialization flow in `src/agent/rlm-runner.ts:64-200` provides a complete template for building AI services, tool registries, and running queries. Adapt this pattern for Sprite agents.
+
+- **Base64 Encoding for File Content**: Using `base64` encoding for file reads/writes ensures binary safety and prevents shell injection from file content. The pattern `cat file | base64` and `echo data | base64 -d | tee file` is well-tested.
+
+- **Tool Names Stay the Same**: Remote tools use the same names as local tools (`Read`, `Write`, `Bash`, etc.) for transparency. The proxying is invisible to the agent.
+
+- **Error Handling Distinguishes Subprocess vs Command Failures**: `execSprite()` throws for subprocess errors (spawn failure, timeout) but returns `success: false` for command failures (non-zero exit code). Remote tools should follow this pattern.
+
+- **VM Initialization is Idempotent**: `ensureSpriteRunning()` checks if VM exists before starting, making it safe to call multiple times.
+
+- **Timeout is Configurable**: The `config.timeout` field (default 300s) applies to all tool operations via `execSprite()`. Long-running commands like `npm install` may need increased timeout.
+
+- **Streaming Output is Supported**: The `onStdoutChunk` and `onStderrChunk` callbacks in `execSprite()` enable real-time output streaming for long-running commands.
+
+- **MCP Tools Can Be Added**: The tool registry supports mixing remote tools with MCP tools. MCP tools execute on host, remote tools execute in VM. Document this security distinction.
+
+- **Allowlist System Works Transparently**: Since remote tools keep the same names as local tools, the existing `PHASE_TOOL_ALLOWLISTS` work without modification.
+
+- **Authentication is Handled**: The `SPRITES_TOKEN` environment variable is already injected via `runWispCommand()` at lines 107-110. No additional auth handling needed.
+
+- **Testing Requires Mocking**: Unit tests should mock `execSprite()` to avoid requiring actual Sprite CLI. Integration tests should test with real VMs if available in CI.
+
+- **Performance Consideration**: Each tool call spawns a new `sprite exec` process, which adds latency. Document this expectation; optimize with caching if needed.
+
+- **Security Guarantee**: By intercepting all tool calls and routing through `sprite exec`, we ensure the agent never directly accesses the host filesystem. This provides true sandbox isolation.
+
+- **Backward Compatibility**: Adding remote tool proxying doesn't break existing Sprite functionality (start/attach/list/kill). The change is isolated to `runSpriteAgent()`.
+
+- **Graceful Degradation**: If Sprite CLI is not available or VM fails to start, `runSpriteAgent()` returns a clear error. It does NOT fall back to local tools (which would break sandboxing).

--- a/.wreckit/skills.json
+++ b/.wreckit/skills.json
@@ -24,7 +24,8 @@
       "doctor",
       "refactoring",
       "schema-validation",
-      "logging-standardization"
+      "logging-standardization",
+      "backup-restore"
     ],
     "pr": [
       "git-integration",
@@ -576,6 +577,58 @@
           "type": "file",
           "path": "src/logging/index.ts",
           "description": "Logger interface definition"
+        }
+      ]
+    },
+    {
+      "id": "backup-restore",
+      "name": "Backup and Restore",
+      "description": "Creates backups before destructive operations and provides restore capability for rollback. Uses file system operations to backup modified files, tracks backup sessions, and can restore from backups on failure. Based on patterns from item 032 and doctor.ts backup system.",
+      "tools": [
+        "Read",
+        "Write",
+        "Edit",
+        "Bash"
+      ],
+      "required_context": [
+        {
+          "type": "file",
+          "path": ".wreckit/backups/",
+          "description": "Backup directory for existing backup sessions"
+        }
+      ]
+    },
+    {
+      "id": "interactive-cli",
+      "name": "Interactive CLI",
+      "description": "Creates interactive command-line experiences using readline for user input, TTY detection for environment awareness, and formatted console output. Handles user prompts, confirmations, and selections. Based on patterns from items 041 (interactive merge) and 042 (ideas-interview).",
+      "tools": [
+        "Read",
+        "Write",
+        "Edit"
+      ],
+      "required_context": [
+        {
+          "type": "git_status",
+          "description": "Check for TTY environment availability"
+        }
+      ]
+    },
+    {
+      "id": "state-management",
+      "name": "State Management",
+      "description": "Manages application state for UI components and workflows. Creates state factories, update functions, and subscription mechanisms. Based on patterns from TUI dashboard.ts and React state management.",
+      "tools": [
+        "Read",
+        "Write",
+        "Edit",
+        "Grep"
+      ],
+      "required_context": [
+        {
+          "type": "file",
+          "path": "src/tui/dashboard.ts",
+          "description": "Existing state management patterns"
         }
       ]
     }

--- a/src/__tests__/agent/remote-tools.test.ts
+++ b/src/__tests__/agent/remote-tools.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, mock, spyOn } from "bun:test";
+import { buildRemoteToolRegistry } from "../../agent/remote-tools";
+import type { SpriteAgentConfig } from "../../schemas";
+
+function createMockLogger() {
+  return {
+    debug: mock(),
+    info: mock(),
+    warn: mock(),
+    error: mock(),
+    child: () => createMockLogger(),
+  } as any;
+}
+
+// Mock execSprite in sprite-runner module
+const mockExecSprite = mock();
+mock.module("../../agent/sprite-runner", () => ({
+  execSprite: mockExecSprite,
+}));
+
+describe("Remote Tools", () => {
+  const config: SpriteAgentConfig = {
+    kind: "sprite",
+    wispPath: "sprite",
+    maxVMs: 1,
+    defaultMemory: "512MiB",
+    defaultCPUs: "1",
+    timeout: 300,
+  };
+  const logger = createMockLogger();
+  const vmName = "test-vm";
+
+  beforeEach(() => {
+    mockExecSprite.mockReset();
+  });
+
+  it("Remote Read Tool: reads file via base64", async () => {
+    const tools = buildRemoteToolRegistry(vmName, config, logger);
+    const readTool = tools.find((t) => t.name === "Read");
+    expect(readTool).toBeDefined();
+
+    // Mock successful execution
+    // "Hello World" in base64 is "SGVsbG8gV29ybGQ="
+    mockExecSprite.mockResolvedValue({
+      success: true,
+      stdout: "SGVsbG8gV29ybGQ=",
+      stderr: "",
+      exitCode: 0,
+    });
+
+    const result = await readTool!.func({ file_path: "test.txt" });
+    expect(result).toBe("Hello World");
+    
+    // Verify arguments
+    const calls = mockExecSprite.mock.calls;
+    expect(calls.length).toBe(1);
+    expect(calls[0][0]).toBe(vmName);
+    expect(calls[0][1]).toEqual(["sh", "-c", 'cat "test.txt" | base64']);
+  });
+
+  it("Remote Write Tool: writes file via base64", async () => {
+    const tools = buildRemoteToolRegistry(vmName, config, logger);
+    const writeTool = tools.find((t) => t.name === "Write");
+    expect(writeTool).toBeDefined();
+
+    mockExecSprite.mockResolvedValue({
+      success: true,
+      stdout: "",
+      stderr: "",
+      exitCode: 0,
+    });
+
+    const content = "Hello World";
+    // base64 is SGVsbG8gV29ybGQ=
+    const result = await writeTool!.func({
+      file_path: "test.txt",
+      content,
+    });
+
+    expect(result).toContain("Successfully wrote");
+    
+    const args = mockExecSprite.mock.calls[0][1];
+    expect(args[2]).toContain('echo "SGVsbG8gV29ybGQ=" | base64 -d > "test.txt"');
+  });
+
+  it("Remote Bash Tool: executes command directly", async () => {
+    const tools = buildRemoteToolRegistry(vmName, config, logger);
+    const bashTool = tools.find((t) => t.name === "Bash");
+    expect(bashTool).toBeDefined();
+
+    mockExecSprite.mockResolvedValue({
+      success: true,
+      stdout: "command output",
+      stderr: "",
+      exitCode: 0,
+    });
+
+    const result = await bashTool!.func({ command: "ls -la" });
+    expect(result).toBe("command output");
+
+    const args = mockExecSprite.mock.calls[0][1];
+    expect(args).toEqual(["bash", "-c", "ls -la"]);
+  });
+  
+  it("Handles execution errors gracefully", async () => {
+    const tools = buildRemoteToolRegistry(vmName, config, logger);
+    const bashTool = tools.find((t) => t.name === "Bash");
+    
+    mockExecSprite.mockResolvedValue({
+      success: false,
+      stdout: "",
+      stderr: "Command not found",
+      exitCode: 127,
+    });
+
+    const result = await bashTool!.func({ command: "invalid" });
+    expect(result).toContain("Command failed with exit code 127");
+    expect(result).toContain("Stderr: Command not found");
+  });
+});

--- a/src/agent/remote-tools.ts
+++ b/src/agent/remote-tools.ts
@@ -1,0 +1,286 @@
+import {
+  type AxFunction,
+  type AxFunctionJSONSchema,
+} from "@ax-llm/ax";
+import type { Logger } from "../logging";
+import type { SpriteAgentConfig } from "../schemas";
+import { execSprite } from "./sprite-runner";
+import { SpriteExecError } from "../errors";
+
+/**
+ * Build a registry of remote tools that execute inside a Sprite VM.
+ */
+export function buildRemoteToolRegistry(
+  vmName: string,
+  config: SpriteAgentConfig,
+  logger: Logger,
+  allowedTools?: string[]
+): AxFunction[] {
+  const remoteTools = [
+    createRemoteReadTool(vmName, config, logger),
+    createRemoteWriteTool(vmName, config, logger),
+    createRemoteBashTool(vmName, config, logger),
+    createRemoteGlobTool(vmName, config, logger),
+    createRemoteGrepTool(vmName, config, logger),
+  ];
+
+  if (allowedTools) {
+    return remoteTools.filter((tool) => allowedTools.includes(tool.name));
+  }
+
+  return remoteTools;
+}
+
+function createRemoteReadTool(
+  vmName: string,
+  config: SpriteAgentConfig,
+  logger: Logger
+): AxFunction {
+  return {
+    name: "Read",
+    description: "Read a file from the filesystem inside the Sprite VM.",
+    parameters: {
+      type: "object",
+      properties: {
+        file_path: {
+          type: "string",
+          description: "The path to the file to read",
+        },
+      },
+      required: ["file_path"],
+    } as AxFunctionJSONSchema,
+    func: async ({ file_path }: { file_path: string }) => {
+      try {
+        // Use cat | base64 to safely read binary content
+        const result = await execSprite(
+          vmName,
+          ["sh", "-c", `cat \"${file_path}\" | base64`],
+          config,
+          logger
+        );
+
+        if (!result.success && result.exitCode !== 0) {
+          return `Error reading file ${file_path}: ${result.stderr}`;
+        }
+
+        const content = Buffer.from(result.stdout.trim(), "base64").toString(
+          "utf-8"
+        );
+        return content;
+      } catch (error: any) {
+        if (error instanceof SpriteExecError) {
+          return `Failed to execute read command: ${error.message}`;
+        }
+        return `Error reading file: ${error.message}`;
+      }
+    },
+  };
+}
+
+function createRemoteWriteTool(
+  vmName: string,
+  config: SpriteAgentConfig,
+  logger: Logger
+): AxFunction {
+  return {
+    name: "Write",
+    description: "Write content to a file inside the Sprite VM.",
+    parameters: {
+      type: "object",
+      properties: {
+        file_path: {
+          type: "string",
+          description: "The path to the file to write to",
+        },
+        content: {
+          type: "string",
+          description: "The content to write to the file",
+        },
+      },
+      required: ["file_path", "content"],
+    } as AxFunctionJSONSchema,
+    func: async ({
+      file_path,
+      content,
+    }: { file_path: string; content: string }) => {
+      try {
+        // Use base64 | decode > file to safely write content
+        const base64Content = Buffer.from(content).toString("base64");
+        // We write the base64 string to a temp file then decode it, to avoid command line length limits/quoting hell
+        // Actually, piping echo is risky if too long.
+        // Better: write base64 to a temp file using printf or similar if possible, but echo is standard.
+        // For now, simple echo | base64 -d > file.
+        const result = await execSprite(
+          vmName,
+          [
+            "sh",
+            "-c",
+            `echo \"${base64Content}\" | base64 -d > \"${file_path}\" `,
+          ],
+          config,
+          logger
+        );
+
+        if (!result.success && result.exitCode !== 0) {
+          return `Error writing file ${file_path}: ${result.stderr}`;
+        }
+
+        return `Successfully wrote to ${file_path}`;
+      } catch (error: any) {
+        return `Error writing file: ${error.message}`;
+      }
+    },
+  };
+}
+
+function createRemoteBashTool(
+  vmName: string,
+  config: SpriteAgentConfig,
+  logger: Logger
+): AxFunction {
+  return {
+    name: "Bash",
+    description: "Execute a bash command inside the Sprite VM.",
+    parameters: {
+      type: "object",
+      properties: {
+        command: {
+          type: "string",
+          description: "The bash command to execute",
+        },
+      },
+      required: ["command"],
+    } as AxFunctionJSONSchema,
+    func: async ({ command }: { command: string }) => {
+      try {
+        const result = await execSprite(
+          vmName,
+          ["bash", "-c", command],
+          config,
+          logger
+        );
+
+        if (result.exitCode !== 0) {
+          return `Command failed with exit code ${result.exitCode}\nStdout: ${result.stdout}\nStderr: ${result.stderr}`;
+        }
+
+        return result.stdout;
+      } catch (error: any) {
+        return `Error executing command: ${error.message}`;
+      }
+    },
+  };
+}
+
+function createRemoteGlobTool(
+  vmName: string,
+  config: SpriteAgentConfig,
+  logger: Logger
+): AxFunction {
+  return {
+    name: "Glob",
+    description: "Find files matching a glob pattern inside the Sprite VM.",
+    parameters: {
+      type: "object",
+      properties: {
+        pattern: {
+          type: "string",
+          description: "The glob pattern to match (e.g. **/*.ts)",
+        },
+        path: {
+          type: "string",
+          description: "The directory to search in (optional)",
+        },
+      },
+      required: ["pattern"],
+    } as AxFunctionJSONSchema,
+    func: async ({ pattern, path }: { pattern: string; path?: string }) => {
+      try {
+        // Map glob pattern to find command
+        // Simple mapping: **/*.ts -> -name "*.ts"
+        // This is a simplification. Ideally we'd use a real glob tool inside.
+        // For now, let's assume 'find' is available.
+        // If pattern contains **, use -name.
+        const searchPath = path || ".";
+        const namePattern = pattern.replace("**/", ""); // Very naive
+        
+        // Better: just use `find . -name "pattern"`
+        // Or if the VM has `glob` or python, use that.
+        // Most robust: `find <path> -name "<pattern>"
+        
+        const result = await execSprite(
+            vmName,
+            ["find", searchPath, "-name", namePattern],
+            config,
+            logger
+        );
+
+        if (result.exitCode !== 0) {
+            return `Error finding files: ${result.stderr}`;
+        }
+        return result.stdout;
+      } catch (error: any) {
+        return `Error executing glob: ${error.message}`;
+      }
+    },
+  };
+}
+
+function createRemoteGrepTool(
+  vmName: string,
+  config: SpriteAgentConfig,
+  logger: Logger
+): AxFunction {
+  return {
+    name: "Grep",
+    description: "Search for a pattern in files inside the Sprite VM.",
+    parameters: {
+      type: "object",
+      properties: {
+        pattern: {
+          type: "string",
+          description: "The pattern to search for",
+        },
+        path: {
+          type: "string",
+          description: "The directory to search in (optional)",
+        },
+        include: {
+          type: "string",
+          description: "File pattern to include (optional)",
+        },
+      },
+      required: ["pattern"],
+    } as AxFunctionJSONSchema,
+    func: async ({
+      pattern,
+      path,
+      include,
+    }: {
+      pattern: string;
+      path?: string;
+      include?: string;
+    }) => {
+      try {
+        const searchPath = path || ".";
+        const includeArg = include ? `--include="${include}"` : "";
+
+        // Arguments need to be filtered to remove empty strings if any
+        const args = ["grep", "-r"];
+        if (includeArg) args.push(includeArg);
+        args.push(pattern);
+        args.push(searchPath);
+
+        const result = await execSprite(vmName, args, config, logger);
+
+        if (result.exitCode !== 0 && result.exitCode !== 1) {
+          // 1 means no matches, which is fine
+          return `Error searching: ${result.stderr}`;
+        }
+        return result.stdout || "No matches found.";
+      } catch (error: any) {
+        return `Error executing grep: ${error.message}`;
+      }
+    },
+  };
+}

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -83,6 +83,12 @@ export const SpriteAgentSchema = z.object({
     .describe(
       "Sprites.dev authentication token (optional, can use SPRITES_TOKEN env var)",
     ),
+  vmName: z
+    .string()
+    .optional()
+    .describe(
+      "Name of the Sprite VM to use (auto-generated if not provided)",
+    ),
   maxVMs: z.number().default(5).describe("Maximum concurrent VMs allowed"),
   defaultMemory: z
     .string()


### PR DESCRIPTION
### **User description**
## Overview

Implement a proxy layer that redirects standard agent tools (Bash, Read, Write, Glob, Grep) to execute inside a remote Sprite VM via `sprite exec`. This transforms the `SpriteAgent` into a fully functional, sandboxed runtime environment where agents operate safely in isolation from the host filesystem.

---

*Automated PR created by wreckit*


___

### **PR Type**
Enhancement


___

### **Description**
- Implement remote tool proxy layer for Sprite agents
  - Create `buildRemoteToolRegistry()` with Read, Write, Bash, Glob, Grep tools
  - Use base64 encoding for binary-safe file operations via `execSprite()`

- Rewrite `runSpriteAgent()` to execute full agent loop inside VM
  - Initialize AxAgent with AI service and remote tools
  - Implement `ensureSpriteRunning()` to auto-start/connect to Sprite VM
  - Support streaming output and timeout handling

- Add `vmName` field to `SpriteAgentConfig` schema

- Add comprehensive unit tests for remote tool proxying


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Agent Prompt"] --> B["runSpriteAgent()"]
  B --> C["ensureSpriteRunning()"]
  C --> D["Start/Connect VM"]
  B --> E["buildRemoteToolRegistry()"]
  E --> F["Remote Tools"]
  F --> G["execSprite()"]
  G --> H["Sprite VM"]
  B --> I["AxAgent Init"]
  I --> J["AI Service"]
  J --> K["Agent Loop"]
  K --> F
  K --> L["Output Stream"]
  L --> M["AgentResult"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>remote-tools.ts</strong><dd><code>Create remote tool implementations for Sprite VM execution</code></dd></td>
  <td><a href="https://github.com/jmanhype/wreckit/pull/32/files#diff-e8d5d33a2c51ea3e03f158235021a5852a0d1a05d8028773c3c492df22f58327">+286/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>sprite-runner.ts</strong><dd><code>Rewrite runSpriteAgent with full AxAgent execution loop</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jmanhype/wreckit/pull/32/files#diff-ac45e9ebc7318a5f0086eedb4f2eb6e0f1ecd74220d6f2947d97e7a28dac2dd0">+176/-89</a></td>

</tr>

<tr>
  <td><strong>schemas.ts</strong><dd><code>Add vmName field to SpriteAgentConfig schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jmanhype/wreckit/pull/32/files#diff-8f5fdeb1cfe9f99fbc1c0a2c351f90ef3531ecdeefa8d0f9a4f0f4127c67f2aa">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>remote-tools.test.ts</strong><dd><code>Add unit tests for remote tool proxy layer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jmanhype/wreckit/pull/32/files#diff-635b40240f1eccddc16321173df1cc196d3efd39789657eb7845bfe5d3678e5b">+120/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>item.json</strong><dd><code>Mark item 075 as done with PR reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jmanhype/wreckit/pull/32/files#diff-71ad61636c458c90db89a69f9e0b51c2433206a5a8c64ba52ed454453cc68192">+9/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>item.json</strong><dd><code>Create item tracking for remote tool proxy feature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jmanhype/wreckit/pull/32/files#diff-c88dd789274400c1a0e85c5cc8a0ce9b645aed6a7a767fc61d7a2da197d7aa59">+38/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>plan.md</strong><dd><code>Add implementation plan for remote tool proxy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jmanhype/wreckit/pull/32/files#diff-3d5e4c0962dfc305d3cfacf6dd9eaeea4ffbd3e9b014ae1fd6eada2e07d97e15">+36/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>prd.json</strong><dd><code>Add product requirements and user stories</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jmanhype/wreckit/pull/32/files#diff-b50ac93d2fc60950b6cd4d56e1939f6aaed4b4af61a9eeb0b4330fa27a40f91a">+57/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>research.md</strong><dd><code>Add comprehensive research and technical analysis</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/jmanhype/wreckit/pull/32/files#diff-ef3daf1d326cfbdb12fec73bf004983c6559bb2993e5efe79d4094ab3c6cbe90">+544/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>skills.json</strong><dd><code>Add backup-restore, interactive-cli, state-management skills</code></dd></td>
  <td><a href="https://github.com/jmanhype/wreckit/pull/32/files#diff-ede97384ae749c2d8ca531a04d587e3b464275e43278077e67ad2751d152deb9">+54/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

